### PR TITLE
backwards compatibility loading

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -25,7 +25,7 @@ def pytest_collection_modifyitems(config, items):
     skip_internet = pytest.mark.skip(reason="need --internet-tests option to run")
     for item in items:
         # All tests marked with `pytest.mark.internet` get skipped unless
-        # `--run-internet` passed
+        # `--internet-tests` passed
         if not run_internet and ("internet" in item.keywords):
             item.add_marker(skip_internet)
 

--- a/scvi/model/base/_base_model.py
+++ b/scvi/model/base/_base_model.py
@@ -20,7 +20,12 @@ from scvi.dataloaders import AnnDataLoader
 from scvi.model._utils import parse_use_gpu_arg
 from scvi.module.base import PyroBaseModuleClass
 
-from ._utils import _initialize_model, _load_saved_files, _validate_var_names
+from ._utils import (
+    _attempt_backwards_compatible_load,
+    _initialize_model,
+    _load_saved_files,
+    _validate_var_names,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -348,6 +353,10 @@ class BaseModelClass(ABC):
                 pyro.clear_param_store()
                 model.module.load_state_dict(model_state_dict)
             else:
+                success = _attempt_backwards_compatible_load(
+                    model.module, model_state_dict
+                )
+            if success is not True:
                 raise err
 
         model.to_device(device)

--- a/scvi/model/base/_base_model.py
+++ b/scvi/model/base/_base_model.py
@@ -20,12 +20,7 @@ from scvi.dataloaders import AnnDataLoader
 from scvi.model._utils import parse_use_gpu_arg
 from scvi.module.base import PyroBaseModuleClass
 
-from ._utils import (
-    _attempt_backwards_compatible_load,
-    _initialize_model,
-    _load_saved_files,
-    _validate_var_names,
-)
+from ._utils import _initialize_model, _load_saved_files, _validate_var_names
 
 logger = logging.getLogger(__name__)
 
@@ -353,10 +348,6 @@ class BaseModelClass(ABC):
                 pyro.clear_param_store()
                 model.module.load_state_dict(model_state_dict)
             else:
-                success = _attempt_backwards_compatible_load(
-                    model.module, model_state_dict
-                )
-            if success is not True:
                 raise err
 
         model.to_device(device)

--- a/scvi/model/base/_utils.py
+++ b/scvi/model/base/_utils.py
@@ -1,7 +1,6 @@
 import logging
 import os
 import pickle
-from collections import OrderedDict
 from collections.abc import Iterable as IterableClass
 from typing import Optional
 
@@ -84,20 +83,6 @@ def _validate_var_names(adata, source_var_names):
             "adata used to train the model. For valid results, the vars "
             "need to be the same and in the same order as the adata used to train the model."
         )
-
-
-def _attempt_backwards_compatible_load(module, model_state_dict):
-    # loading from 0.8 models
-    try:
-        new_model_state_dict = OrderedDict()
-        for key, value in model_state_dict.items():
-            new_key = key.replace(" ", "_")
-            new_model_state_dict.update({new_key: value})
-        module.load_state_dict(new_model_state_dict)
-    except RuntimeError:
-        return False
-
-    return True
 
 
 def _de_core(

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -232,7 +232,7 @@ def test_saving_and_loading(save_path):
 def test_backwards_compatible_loading(save_path):
     def download_080_models(save_path):
         file_path = (
-            "https://github.com/galenxing/scVI-data/raw/master/testing_models.tar.gz"
+            "https://github.com/yoseflab/scVI-data/raw/master/testing_models.tar.gz"
         )
         save_fn = "testing_models.tar.gz"
         _download(file_path, save_path, save_fn)


### PR DESCRIPTION
allows loading of models from scvi version 0.8.0

- still need to double check other versions
- need to add tests (after merging trained models into scvi-data)