### PR TITLE
pyro abstract module fixes

### DIFF
--- a/scvi/module/base/_base_module.py
+++ b/scvi/module/base/_base_module.py
@@ -208,7 +208,8 @@ class PyroBaseModuleClass(nn.Module):
 
     There are two ways this class can be equipped with a model and a guide. First,
     `model` and `guide` can be class attributes that are :class:`~pyro.nn.PyroModule`
-    instances. Second, `model` and `guide` methods can be written (see Pyro scANVI example)
+    instances. The implemented `model` and `guide` class method can then return the (private) attributes.
+    Second, `model` and `guide` methods can be written directly (see Pyro scANVI example)
     https://pyro.ai/examples/scanvi.html
     """
 
@@ -232,6 +233,16 @@ class PyroBaseModuleClass(nn.Module):
         -------
         args and kwargs for the functions, args should be an Iterable and kwargs a dictionary.
         """
+
+    @property
+    @abstractmethod
+    def model(self):
+        pass
+
+    @property
+    @abstractmethod
+    def guide(self):
+        pass
 
     def create_predictive(
         self,

--- a/scvi/module/base/_base_module.py
+++ b/scvi/module/base/_base_module.py
@@ -210,7 +210,13 @@ class PyroBaseModuleClass(nn.Module):
     `model` and `guide` can be class attributes that are :class:`~pyro.nn.PyroModule`
     instances. The implemented `model` and `guide` class method can then return the (private) attributes.
     Second, `model` and `guide` methods can be written directly (see Pyro scANVI example)
-    https://pyro.ai/examples/scanvi.html
+    https://pyro.ai/examples/scanvi.html.
+
+    The `model` and `guide` may also be equipped with `n_obs` attributes, which can be set
+    to `None` (e.g., `self.n_obs = None`). This attribute may be helpful in designating the
+    size of observation-specific Pyro plates. The value will be updated automatically by
+    :class:`~scvi.train.PyroTrainingPlan`, provided that it is given the number of training examples
+    upon initialization.
     """
 
     def __init__(self):

--- a/tests/models/test_pyro.py
+++ b/tests/models/test_pyro.py
@@ -73,8 +73,16 @@ class BayesianRegressionModule(PyroBaseModuleClass):
     def __init__(self, in_features, out_features):
 
         super().__init__()
-        self.model = BayesianRegressionPyroModel(in_features, out_features)
-        self.guide = AutoDiagonalNormal(self.model)
+        self._model = BayesianRegressionPyroModel(in_features, out_features)
+        self._guide = AutoDiagonalNormal(self.model)
+
+    @property
+    def model(self):
+        return self._model
+
+    @property
+    def guide(self):
+        return self._guide
 
     @staticmethod
     def _get_fn_args_from_batch(tensor_dict):

--- a/tests/models/test_pyro.py
+++ b/tests/models/test_pyro.py
@@ -44,6 +44,7 @@ class BayesianRegressionPyroModel(PyroModule):
         super().__init__()
         self.in_features = in_features
         self.out_features = out_features
+        self.n_obs = None
 
         self.register_buffer("zero", torch.tensor(0.0))
         self.register_buffer("one", torch.tensor(1.0))
@@ -64,7 +65,7 @@ class BayesianRegressionPyroModel(PyroModule):
     def forward(self, x, y):
         sigma = pyro.sample("sigma", dist.Uniform(self.zero, self.ten))
         mean = self.linear(x).squeeze(-1)
-        with pyro.plate("data", x.shape[0]):
+        with pyro.plate("data", size=self.n_obs, subsample_size=x.shape[0]):
             pyro.sample("obs", dist.Normal(mean, sigma), obs=y)
         return mean
 
@@ -98,7 +99,7 @@ def test_pyro_bayesian_regression(save_path):
     train_dl = AnnDataLoader(adata, shuffle=True, batch_size=128)
     pyro.clear_param_store()
     model = BayesianRegressionModule(adata.shape[1], 1)
-    plan = PyroTrainingPlan(model)
+    plan = PyroTrainingPlan(model, n_obs=len(train_dl.indices))
     trainer = Trainer(
         gpus=use_gpu,
         max_epochs=2,
@@ -134,7 +135,7 @@ def test_pyro_bayesian_regression(save_path):
         new_model.load_state_dict(torch.load(model_save_path))
     except RuntimeError as err:
         if isinstance(new_model, PyroBaseModuleClass):
-            plan = PyroTrainingPlan(new_model)
+            plan = PyroTrainingPlan(new_model, n_obs=len(train_dl.indices))
             trainer = Trainer(
                 gpus=use_gpu,
                 max_steps=1,
@@ -159,7 +160,9 @@ def test_pyro_bayesian_regression_jit():
     pyro.clear_param_store()
     model = BayesianRegressionModule(adata.shape[1], 1)
     train_dl = AnnDataLoader(adata, shuffle=True, batch_size=128)
-    plan = PyroTrainingPlan(model, loss_fn=pyro.infer.JitTrace_ELBO())
+    plan = PyroTrainingPlan(
+        model, loss_fn=pyro.infer.JitTrace_ELBO(), n_obs=len(train_dl.indices)
+    )
     trainer = Trainer(
         gpus=use_gpu, max_epochs=2, callbacks=[PyroJitGuideWarmup(train_dl)]
     )


### PR DESCRIPTION
- Better enforces having a model and guide in the wrapper torch nn module
- Handles number of training examples being set during `train()`, which properly weights when there are local and global latent vars