### PR TITLE
Tutorial links

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -165,13 +165,13 @@ nbsphinx_prolog = r"""
     <p class="admonition-title">Note</p>
     <p>
       This page was generated from
-      <a class="reference external" href="https://github.com/yoseflab/scvi-tutorials/tree/{version}/">{{ docname|e }}</a>.
+      <a class="reference external" href="https://github.com/yoseflab/scvi-tutorials/tree/{version}/">{docname}</a>.
       Interactive online version:
-      <span style="white-space: nowrap;"><a href="https://colab.research.google.com/github/yoseflab/scvi_tutorials/blob/{version}/{{ docname|e }}"><img alt="Colab badge" src="https://colab.research.google.com/assets/colab-badge.svg" style="vertical-align:text-bottom"></a>.</span>
+      <span style="white-space: nowrap;"><a href="https://colab.research.google.com/github/yoseflab/scvi_tutorials/blob/{version}/{docname}"><img alt="Colab badge" src="https://colab.research.google.com/assets/colab-badge.svg" style="vertical-align:text-bottom"></a>.</span>
     </p>
     </div>
 """.format(
-    version=version
+    version=version, docname="{{ docname|e }}"
 )
 nbsphinx_thumbnails = {
     "user_guide/notebooks/data_loading": "_static/tutorials/anndata.svg",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -157,7 +157,7 @@ html_show_sphinx = False
 nbsphinx_prolog = r"""
 .. raw:: html
 
-{% set docname = env.doc2path(env.docname, base=None).split("/")[-1] %}
+{{% set docname = env.doc2path(env.docname, base=None).split("/")[-1] %}}
 
 .. raw:: html
 
@@ -165,12 +165,14 @@ nbsphinx_prolog = r"""
     <p class="admonition-title">Note</p>
     <p>
       This page was generated from
-      <a class="reference external" href="https://github.com/yoseflab/scvi-tutorials/">{{ docname|e }}</a>.
+      <a class="reference external" href="https://github.com/yoseflab/scvi-tutorials/tree/{version}/">{{ docname|e }}</a>.
       Interactive online version:
-      <span style="white-space: nowrap;"><a href="https://colab.research.google.com/github/yoseflab/scvi_tutorials/blob/master/{{ docname|e }}"><img alt="Colab badge" src="https://colab.research.google.com/assets/colab-badge.svg" style="vertical-align:text-bottom"></a>.</span>
+      <span style="white-space: nowrap;"><a href="https://colab.research.google.com/github/yoseflab/scvi_tutorials/blob/{version}/{{ docname|e }}"><img alt="Colab badge" src="https://colab.research.google.com/assets/colab-badge.svg" style="vertical-align:text-bottom"></a>.</span>
     </p>
     </div>
-"""
+""".format(
+    version=version
+)
 nbsphinx_thumbnails = {
     "user_guide/notebooks/data_loading": "_static/tutorials/anndata.svg",
     "user_guide/notebooks/api_overview": "_static/tutorials/overview.svg",

--- a/docs/contributing/index.rst
+++ b/docs/contributing/index.rst
@@ -128,7 +128,7 @@ $ poetry version preversion # possible: major / minor / patch
 $ poetry build
 $ poetry publish
 
-This will upload `scvi-tools` to PyPi
+This will upload `scvi-tools` to PyPi. Also be sure to add a tag corresponding to the new version number on the tutorials repo, as the tagged repo is used for the Colab links.
 
 
 Instructions on Uploading to conda


### PR DESCRIPTION
This adds versions to the URLs of the notebook colab badges and links, so that if you go to an older version of the docs, the link will take you to a tagged link on the tutorials repo.

Closes #987 