### PR TITLE
Fix SaveBestState warning on first epoch

### DIFF
--- a/scvi/train/_callbacks.py
+++ b/scvi/train/_callbacks.py
@@ -82,11 +82,11 @@ class SaveBestState(Callback):
         logs = trainer.callback_metrics
         self.epochs_since_last_check += 1
 
-        if self.epochs_since_last_check >= self.period:
+        if trainer.current_epoch > 0 and self.epochs_since_last_check >= self.period:
             self.epochs_since_last_check = 0
             current = logs.get(self.monitor)
 
-            if trainer.current_epoch > 0 and current is None:
+            if current is None:
                 warnings.warn(
                     f"Can save best module state only with {self.monitor} available,"
                     " skipping.",

--- a/scvi/train/_callbacks.py
+++ b/scvi/train/_callbacks.py
@@ -105,5 +105,8 @@ class SaveBestState(Callback):
                             f" Module best state updated."
                         )
 
+    def on_train_start(self, trainer, pl_module):
+        self.best_module_state = deepcopy(pl_module.module.state_dict())
+
     def on_train_end(self, trainer, pl_module):
         pl_module.module.load_state_dict(self.best_module_state)

--- a/scvi/train/_callbacks.py
+++ b/scvi/train/_callbacks.py
@@ -86,7 +86,7 @@ class SaveBestState(Callback):
             self.epochs_since_last_check = 0
             current = logs.get(self.monitor)
 
-            if current is None:
+            if trainer.current_epoch > 0 and current is None:
                 warnings.warn(
                     f"Can save best module state only with {self.monitor} available,"
                     " skipping.",


### PR DESCRIPTION
SaveBestState callback prints a warning on the first epoch since `current` is None at that point. Fixed to check only after the first epoch.