### PR TITLE
use data modules for splitters

### DIFF
--- a/scvi/dataloaders/__init__.py
+++ b/scvi/dataloaders/__init__.py
@@ -1,13 +1,18 @@
 from ._ann_dataloader import AnnDataLoader
 from ._anntorchdataset import AnnTorchDataset
 from ._concat_dataloader import ConcatDataLoader
-from ._data_splitting import DataSplitter, SemiSupervisedDataSplitter
+from ._data_splitting import (
+    DataSplitter,
+    DeviceBackedDataSplitter,
+    SemiSupervisedDataSplitter,
+)
 from ._semi_dataloader import SemiSupervisedDataLoader
 
 __all__ = [
     "AnnDataLoader",
     "AnnTorchDataset",
     "ConcatDataLoader",
+    "DeviceBackedDataSplitter",
     "SemiSupervisedDataLoader",
     "DataSplitter",
     "SemiSupervisedDataSplitter",

--- a/scvi/dataloaders/_data_splitting.py
+++ b/scvi/dataloaders/_data_splitting.py
@@ -430,5 +430,5 @@ class _DeviceBackedDataset(Dataset):
         return return_dict
 
     def __len__(self):
-        for key, value in self.data.items():
+        for _, value in self.data.items():
             return len(value)

--- a/scvi/dataloaders/_data_splitting.py
+++ b/scvi/dataloaders/_data_splitting.py
@@ -75,7 +75,8 @@ class DataSplitter(pl.LightningDataModule):
     --------
     >>> adata = scvi.data.synthetic_iid()
     >>> splitter = DataSplitter(adata)
-    >>> train_dl, val_dl, test_dl = splitter()
+    >>> splitter.setup()
+    >>> train_dl = splitter.train_dataloader()
     """
 
     def __init__(
@@ -175,7 +176,8 @@ class SemiSupervisedDataSplitter(pl.LightningDataModule):
     >>> adata = scvi.data.synthetic_iid()
     >>> unknown_label = 'label_0'
     >>> splitter = SemiSupervisedDataSplitter(adata, unknown_label)
-    >>> train_dl, val_dl, test_dl = splitter()
+    >>> splitter.setup()
+    >>> train_dl = splitter.train_dataloader()
     """
 
     def __init__(

--- a/scvi/dataloaders/_data_splitting.py
+++ b/scvi/dataloaders/_data_splitting.py
@@ -67,7 +67,8 @@ class DataSplitter(pl.LightningDataModule):
     validation_size
         float, or None (default is None)
     use_gpu
-        Which GPU to use
+        Use default GPU if available (if None or True), or index of GPU to use (if int),
+        or name of GPU (if str, e.g., `'cuda:0'`), or use CPU (if False).
     **kwargs
         Keyword args for data loader. If adata has labeled data, data loader
         class is :class:`~scvi.dataloaders.SemiSupervisedDataLoader`,
@@ -168,6 +169,9 @@ class SemiSupervisedDataSplitter(pl.LightningDataModule):
         float, or None (default is None)
     n_samples_per_label
         Number of subsamples for each label class to sample per epoch
+    use_gpu
+        Use default GPU if available (if None or True), or index of GPU to use (if int),
+        or name of GPU (if str, e.g., `'cuda:0'`), or use CPU (if False).
     **kwargs
         Keyword args for data loader. If adata has labeled data, data loader
         class is :class:`~scvi.dataloaders.SemiSupervisedDataLoader`,
@@ -315,7 +319,7 @@ class SemiSupervisedDataSplitter(pl.LightningDataModule):
             pass
 
 
-class DeviceBackedDataSplitter(pl.LightningDataModule):
+class DeviceBackedDataSplitter(DataSplitter):
     """
     Creates loaders for data that is already on device, e.g., GPU.
 
@@ -330,7 +334,8 @@ class DeviceBackedDataSplitter(pl.LightningDataModule):
     validation_size
         float, or None (default is None)
     use_gpu
-        Which GPU to use
+        Use default GPU if available (if None or True), or index of GPU to use (if int),
+        or name of GPU (if str, e.g., `'cuda:0'`), or use CPU (if False).
     shuffle
         if ``True``, shuffles indices before sampling
     batch_size
@@ -378,6 +383,7 @@ class DeviceBackedDataSplitter(pl.LightningDataModule):
             dl = AnnDataLoader(
                 self.adata,
                 indices=indices,
+                batch_size=len(indices),
                 shuffle=False,
                 pin_memory=self.pin_memory,
                 **self.data_loader_kwargs,

--- a/scvi/external/cellassign/_model.py
+++ b/scvi/external/cellassign/_model.py
@@ -200,6 +200,7 @@ class CellAssign(UnsupervisedTrainingMixin, BaseModelClass):
             batch_size=batch_size,
             use_gpu=use_gpu,
         )
+        data_splitter.setup()
         training_plan = TrainingPlan(
             self.module, len(data_splitter.train_idx), **plan_kwargs
         )

--- a/scvi/external/cellassign/_model.py
+++ b/scvi/external/cellassign/_model.py
@@ -200,10 +200,7 @@ class CellAssign(UnsupervisedTrainingMixin, BaseModelClass):
             batch_size=batch_size,
             use_gpu=use_gpu,
         )
-        data_splitter.setup()
-        training_plan = TrainingPlan(
-            self.module, len(data_splitter.train_idx), **plan_kwargs
-        )
+        training_plan = TrainingPlan(self.module, **plan_kwargs)
         runner = TrainRunner(
             self,
             training_plan=training_plan,

--- a/scvi/external/gimvi/_model.py
+++ b/scvi/external/gimvi/_model.py
@@ -195,7 +195,6 @@ class GIMVI(VAEMixin, BaseModelClass):
         plan_kwargs = plan_kwargs if isinstance(plan_kwargs, dict) else dict()
         self._training_plan = GIMVITrainingPlan(
             self.module,
-            len(self.train_indices_),
             adversarial_classifier=True,
             scale_adversarial_loss=kappa,
             **plan_kwargs,

--- a/scvi/external/gimvi/_model.py
+++ b/scvi/external/gimvi/_model.py
@@ -174,20 +174,22 @@ class GIMVI(VAEMixin, BaseModelClass):
         self.train_indices_, self.test_indices_, self.validation_indices_ = [], [], []
         train_dls, test_dls, val_dls = [], [], []
         for i, ad in enumerate(self.adatas):
-            train, val, test = DataSplitter(
+            ds = DataSplitter(
                 ad,
                 train_size=train_size,
                 validation_size=validation_size,
                 batch_size=batch_size,
                 use_gpu=use_gpu,
-            )()
-            train_dls.append(train)
-            test_dls.append(test)
-            val.mode = i
+            )
+            ds.setup()
+            train_dls.append(ds.train_dataloader())
+            test_dls.append(ds.test_dataloader())
+            val = ds.val_dataloader()
             val_dls.append(val)
-            self.train_indices_.append(train.indices)
-            self.test_indices_.append(test.indices)
-            self.validation_indices_.append(val.indices)
+            val.mode = i
+            self.train_indices_.append(ds.train_idx)
+            self.test_indices_.append(ds.test_idx)
+            self.validation_indices_.append(ds.val_idx)
         train_dl = TrainDL(train_dls)
 
         plan_kwargs = plan_kwargs if isinstance(plan_kwargs, dict) else dict()

--- a/scvi/model/_scanvi.py
+++ b/scvi/model/_scanvi.py
@@ -366,7 +366,6 @@ class SCANVI(RNASeqMixin, VAEMixin, ArchesMixin, BaseModelClass):
             batch_size=batch_size,
             use_gpu=use_gpu,
         )
-        data_splitter.setup()
         training_plan = SemiSupervisedTrainingPlan(self.module, **plan_kwargs)
         if "callbacks" in trainer_kwargs.keys():
             trainer_kwargs["callbacks"].concatenate(sampler_callback)

--- a/scvi/model/_scanvi.py
+++ b/scvi/model/_scanvi.py
@@ -366,6 +366,7 @@ class SCANVI(RNASeqMixin, VAEMixin, ArchesMixin, BaseModelClass):
             batch_size=batch_size,
             use_gpu=use_gpu,
         )
+        data_splitter.setup()
         training_plan = SemiSupervisedTrainingPlan(self.module, **plan_kwargs)
         if "callbacks" in trainer_kwargs.keys():
             trainer_kwargs["callbacks"].concatenate(sampler_callback)

--- a/scvi/model/_totalvi.py
+++ b/scvi/model/_totalvi.py
@@ -251,6 +251,7 @@ class TOTALVI(RNASeqMixin, VAEMixin, ArchesMixin, BaseModelClass):
             batch_size=batch_size,
             use_gpu=use_gpu,
         )
+        data_splitter.setup()
         training_plan = AdversarialTrainingPlan(
             self.module, len(data_splitter.train_idx), **plan_kwargs
         )

--- a/scvi/model/_totalvi.py
+++ b/scvi/model/_totalvi.py
@@ -251,10 +251,7 @@ class TOTALVI(RNASeqMixin, VAEMixin, ArchesMixin, BaseModelClass):
             batch_size=batch_size,
             use_gpu=use_gpu,
         )
-        data_splitter.setup()
-        training_plan = AdversarialTrainingPlan(
-            self.module, len(data_splitter.train_idx), **plan_kwargs
-        )
+        training_plan = AdversarialTrainingPlan(self.module, **plan_kwargs)
         runner = TrainRunner(
             self,
             training_plan=training_plan,

--- a/scvi/model/base/_training_mixin.py
+++ b/scvi/model/base/_training_mixin.py
@@ -60,12 +60,7 @@ class UnsupervisedTrainingMixin:
             batch_size=batch_size,
             use_gpu=use_gpu,
         )
-        # secondary call in trainer fit will be a no-op
-        # sets the train_idx attr
-        data_splitter.setup()
-        training_plan = TrainingPlan(
-            self.module, len(data_splitter.train_idx), **plan_kwargs
-        )
+        training_plan = TrainingPlan(self.module, **plan_kwargs)
 
         es = "early_stopping"
         trainer_kwargs[es] = (

--- a/scvi/model/base/_training_mixin.py
+++ b/scvi/model/base/_training_mixin.py
@@ -60,6 +60,9 @@ class UnsupervisedTrainingMixin:
             batch_size=batch_size,
             use_gpu=use_gpu,
         )
+        # secondary call in trainer fit will be a no-op
+        # sets the train_idx attr
+        data_splitter.setup()
         training_plan = TrainingPlan(
             self.module, len(data_splitter.train_idx), **plan_kwargs
         )

--- a/scvi/train/_trainer.py
+++ b/scvi/train/_trainer.py
@@ -151,4 +151,9 @@ class Trainer(pl.Trainer):
                 category=UserWarning,
                 message="you defined a validation_step but have no val_dataloader",
             )
+            warnings.filterwarnings(
+                action="ignore",
+                category=UserWarning,
+                message="One of given dataloaders is None and it will be skipped",
+            )
             super().fit(*args, **kwargs)

--- a/scvi/train/_trainingplans.py
+++ b/scvi/train/_trainingplans.py
@@ -97,7 +97,8 @@ class TrainingPlan(pl.LightningModule):
 
     @property
     def n_obs_training(self):
-        """Number of observations in the training set.
+        """
+        Number of observations in the training set.
 
         This will update the loss kwargs for loss rescaling.
         """
@@ -620,7 +621,8 @@ class PyroTrainingPlan(pl.LightningModule):
 
     @property
     def n_obs_training(self):
-        """Number of training examples.
+        """
+        Number of training examples.
 
         If not `None`, updates the `n_obs` attr
         of the Pyro module's `model` and `guide`, if they exist.

--- a/scvi/train/_trainrunner.py
+++ b/scvi/train/_trainrunner.py
@@ -63,16 +63,12 @@ class TrainRunner:
         self.trainer = Trainer(max_epochs=max_epochs, gpus=gpus, **trainer_kwargs)
 
     def __call__(self):
-        train_dl, val_dl, test_dl = self.data_splitter()
-        self.model.train_indices = train_dl.indices
-        self.model.test_indices = test_dl.indices
-        self.model.validation_indices = val_dl.indices
+        self.data_splitter.setup()
+        self.model.train_indices = self.data_splitter.train_idx
+        self.model.test_indices = self.data_splitter.test_idx
+        self.model.validation_indices = self.data_splitter.val_idx
 
-        if len(val_dl.indices) == 0:
-            # circumvent the empty data loader problem if all dataset used for training
-            self.trainer.fit(self.training_plan, train_dl)
-        else:
-            self.trainer.fit(self.training_plan, train_dl, val_dl)
+        self.trainer.fit(self.training_plan, self.data_splitter)
         try:
             self.model.history_ = self.trainer.logger.history
         except AttributeError:

--- a/scvi/train/_trainrunner.py
+++ b/scvi/train/_trainrunner.py
@@ -68,6 +68,8 @@ class TrainRunner:
         self.model.test_indices = self.data_splitter.test_idx
         self.model.validation_indices = self.data_splitter.val_idx
 
+        self.training_plan.n_obs_training = len(self.model.train_indices)
+
         self.trainer.fit(self.training_plan, self.data_splitter)
         try:
             self.model.history_ = self.trainer.logger.history

--- a/tests/models/test_pyro.py
+++ b/tests/models/test_pyro.py
@@ -99,7 +99,8 @@ def test_pyro_bayesian_regression(save_path):
     train_dl = AnnDataLoader(adata, shuffle=True, batch_size=128)
     pyro.clear_param_store()
     model = BayesianRegressionModule(adata.shape[1], 1)
-    plan = PyroTrainingPlan(model, n_obs=len(train_dl.indices))
+    plan = PyroTrainingPlan(model)
+    plan.n_obs_training = len(train_dl.indices)
     trainer = Trainer(
         gpus=use_gpu,
         max_epochs=2,
@@ -135,7 +136,8 @@ def test_pyro_bayesian_regression(save_path):
         new_model.load_state_dict(torch.load(model_save_path))
     except RuntimeError as err:
         if isinstance(new_model, PyroBaseModuleClass):
-            plan = PyroTrainingPlan(new_model, n_obs=len(train_dl.indices))
+            plan = PyroTrainingPlan(new_model)
+            plan.n_obs_training = len(train_dl.indices)
             trainer = Trainer(
                 gpus=use_gpu,
                 max_steps=1,
@@ -160,9 +162,8 @@ def test_pyro_bayesian_regression_jit():
     pyro.clear_param_store()
     model = BayesianRegressionModule(adata.shape[1], 1)
     train_dl = AnnDataLoader(adata, shuffle=True, batch_size=128)
-    plan = PyroTrainingPlan(
-        model, loss_fn=pyro.infer.JitTrace_ELBO(), n_obs=len(train_dl.indices)
-    )
+    plan = PyroTrainingPlan(model, loss_fn=pyro.infer.JitTrace_ELBO())
+    plan.n_obs_training = len(train_dl.indices)
     trainer = Trainer(
         gpus=use_gpu, max_epochs=2, callbacks=[PyroJitGuideWarmup(train_dl)]
     )


### PR DESCRIPTION
Fixes #1050 
Fixes #1058 

This also adds a device-backed data splitter, which will be useful for training pyro models on a GPU using SVI.

However, it creates breaking changes for devs

1. No need to call the data splitter anymore (though I assume most have been using our mixin)
2. No need to give the training plans the number of training observations, now we can set it using the property.