### PR TITLE
fix transform batch for models that encode covs

### DIFF
--- a/docs/release_notes/v0.11.0.rst
+++ b/docs/release_notes/v0.11.0.rst
@@ -5,7 +5,7 @@ From the user perspective, this release features the new differential expression
 
 Changes
 ~~~~~~~
-- Pass `n_labels` to :class:`~scvi.module.VAE` from :class`~scvi.model.SCVI` (`#1055`_).
+- Pass `n_labels` to :class:`~scvi.module.VAE` from :class:`~scvi.model.SCVI` (`#1055`_).
 - Require PyTorch lightning > 1.3, add relevant fixes (`#1054`_).
 - Add DestVI reference (`#1060`_).
 - Add PeakVI links to README (`#1046`_).

--- a/docs/release_notes/v0.11.0.rst
+++ b/docs/release_notes/v0.11.0.rst
@@ -14,7 +14,7 @@ Changes
 
 Bug fixes
 ~~~~~~~~~
-- Fix an issue where `transform_batch` options in :class`~scvi.model.TOTALVI` was accidentally altering the batch encoding in the encoder, which leads to poor results (`#1072`_). This bug was introduced in version 0.9.0.
+- Fix an issue where `transform_batch` options in :class:`~scvi.model.TOTALVI` was accidentally altering the batch encoding in the encoder, which leads to poor results (`#1072`_). This bug was introduced in version 0.9.0.
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/docs/release_notes/v0.11.0.rst
+++ b/docs/release_notes/v0.11.0.rst
@@ -12,6 +12,10 @@ Changes
 - Automatic delta and eps computation in differential expression (`#1043`_).
 - Allow doublet ratio parameter to be changed for used in SOLO (`#1066`_).
 
+Bug fixes
+~~~~~~~~~
+- Fix an issue where `transform_batch` options in :class`~scvi.model.TOTALVI` was accidentally altering the batch encoding in the encoder, which leads to poor results (`#1072`_). This bug was introduced in version 0.9.0.
+
 Breaking changes
 ~~~~~~~~~~~~~~~~
 These breaking changes do not affect the user API; though will impact model developers.
@@ -44,5 +48,6 @@ Contributors
 .. _`#1046`: https://github.com/YosefLab/scvi-tools/pull/1046
 .. _`#1066`: https://github.com/YosefLab/scvi-tools/pull/1066
 .. _`#1071`: https://github.com/YosefLab/scvi-tools/pull/1071
+.. _`#1072`: https://github.com/YosefLab/scvi-tools/pull/1072
 
 

--- a/scvi/model/_totalvi.py
+++ b/scvi/model/_totalvi.py
@@ -424,13 +424,12 @@ class TOTALVI(RNASeqMixin, VAEMixin, ArchesMixin, BaseModelClass):
                 px_scale = torch.stack(n_samples * [px_scale])
                 py_scale = torch.stack(n_samples * [py_scale])
             for b in transform_batch:
-                if b is not None:
-                    batch_indices = tensors[_CONSTANTS.BATCH_KEY]
-                    tensors[_CONSTANTS.BATCH_KEY] = torch.ones_like(batch_indices) * b
+                generative_kwargs = dict(transform_batch=b)
                 inference_kwargs = dict(n_samples=n_samples)
-                inference_outputs, generative_outputs = self.module.forward(
+                _, generative_outputs = self.module.forward(
                     tensors=tensors,
                     inference_kwargs=inference_kwargs,
+                    generative_kwargs=generative_kwargs,
                     compute_loss=False,
                 )
                 if library_size == "latent":
@@ -578,13 +577,12 @@ class TOTALVI(RNASeqMixin, VAEMixin, ArchesMixin, BaseModelClass):
             if n_samples > 1:
                 py_mixing = torch.stack(n_samples * [py_mixing])
             for b in transform_batch:
-                if b is not None:
-                    batch_indices = tensors[_CONSTANTS.BATCH_KEY]
-                    tensors[_CONSTANTS.BATCH_KEY] = torch.ones_like(batch_indices) * b
+                generative_kwargs = dict(transform_batch=b)
                 inference_kwargs = dict(n_samples=n_samples)
-                inference_outputs, generative_outputs = self.module.forward(
+                _, generative_outputs = self.module.forward(
                     tensors=tensors,
                     inference_kwargs=inference_kwargs,
+                    generative_kwargs=generative_kwargs,
                     compute_loss=False,
                 )
                 py_mixing += torch.sigmoid(generative_outputs["py_"]["mixing"])[
@@ -841,16 +839,13 @@ class TOTALVI(RNASeqMixin, VAEMixin, ArchesMixin, BaseModelClass):
             x = tensors[_CONSTANTS.X_KEY]
             y = tensors[_CONSTANTS.PROTEIN_EXP_KEY]
 
-            if transform_batch is not None:
-                batch_indices = tensors[_CONSTANTS.BATCH_KEY]
-                tensors[_CONSTANTS.BATCH_KEY] = (
-                    torch.ones_like(batch_indices) * transform_batch
-                )
+            generative_kwargs = dict(transform_batch=transform_batch)
             inference_kwargs = dict(n_samples=n_samples)
             with torch.no_grad():
                 inference_outputs, generative_outputs, = self.module.forward(
                     tensors,
                     inference_kwargs=inference_kwargs,
+                    generative_kwargs=generative_kwargs,
                     compute_loss=False,
                 )
             px_ = generative_outputs["px_"]

--- a/scvi/model/base/_rnamixin.py
+++ b/scvi/model/base/_rnamixin.py
@@ -1,3 +1,4 @@
+import inspect
 import logging
 import warnings
 from functools import partial
@@ -27,6 +28,14 @@ Number = Union[int, float]
 
 class RNASeqMixin:
     """General purpose methods for RNA-seq analysis."""
+
+    def _get_transform_batch_gen_kwargs(self, batch):
+        if "transform_batch" in inspect.signature(self.module.generative).parameters:
+            return dict(transform_batch=batch)
+        else:
+            raise NotImplementedError(
+                "Transforming batches is not implemented for this model."
+            )
 
     @torch.no_grad()
     def get_normalized_expression(
@@ -115,15 +124,12 @@ class RNASeqMixin:
         for tensors in scdl:
             per_batch_exprs = []
             for batch in transform_batch:
-                if batch is not None:
-                    batch_indices = tensors[_CONSTANTS.BATCH_KEY]
-                    tensors[_CONSTANTS.BATCH_KEY] = (
-                        torch.ones_like(batch_indices) * batch
-                    )
+                generative_kwargs = self._get_transform_batch_gen_kwargs(batch)
                 inference_kwargs = dict(n_samples=n_samples)
                 _, generative_outputs = self.module.forward(
                     tensors=tensors,
                     inference_kwargs=inference_kwargs,
+                    generative_kwargs=generative_kwargs,
                     compute_loss=False,
                 )
                 output = generative_outputs[generative_output_key]
@@ -324,15 +330,12 @@ class RNASeqMixin:
         data_loader_list = []
         for tensors in scdl:
             x = tensors[_CONSTANTS.X_KEY]
-            if transform_batch is not None:
-                batch_indices = tensors[_CONSTANTS.BATCH_KEY]
-                tensors[_CONSTANTS.BATCH_KEY] = (
-                    torch.ones_like(batch_indices) * transform_batch
-                )
+            generative_kwargs = self._get_transform_batch_gen_kwargs(transform_batch)
             inference_kwargs = dict(n_samples=n_samples)
             _, generative_outputs = self.module.forward(
                 tensors=tensors,
                 inference_kwargs=inference_kwargs,
+                generative_kwargs=generative_kwargs,
                 compute_loss=False,
             )
             px_scale = generative_outputs["px_scale"]

--- a/scvi/module/_totalvae.py
+++ b/scvi/module/_totalvae.py
@@ -391,7 +391,6 @@ class TOTALVAE(BaseModuleClass):
         batch_index: Optional[torch.Tensor] = None,
         label: Optional[torch.Tensor] = None,
         n_samples=1,
-        transform_batch: Optional[int] = None,
         cont_covs=None,
         cat_covs=None,
     ) -> Dict[str, Union[torch.Tensor, Dict[str, torch.Tensor]]]:
@@ -423,8 +422,6 @@ class TOTALVAE(BaseModuleClass):
             tensor of cell-types labels with shape (batch_size, n_labels)
         n_samples
             Number of samples to sample from approximate posterior
-        transform_batch
-            If not None, will override batch_index
         cont_covs
             Continuous covariates to condition on
         cat_covs

--- a/scvi/module/_totalvae.py
+++ b/scvi/module/_totalvae.py
@@ -335,13 +335,24 @@ class TOTALVAE(BaseModuleClass):
 
     @auto_move_data
     def generative(
-        self, z, library_gene, batch_index, label, cont_covs=None, cat_covs=None
-    ):
+        self,
+        z: torch.Tensor,
+        library_gene: torch.Tensor,
+        batch_index: torch.Tensor,
+        label: torch.Tensor,
+        cont_covs=None,
+        cat_covs=None,
+        transform_batch: Optional[int] = None,
+    ) -> Dict[str, Union[torch.Tensor, Dict[str, torch.Tensor]]]:
         decoder_input = z if cont_covs is None else torch.cat([z, cont_covs], dim=-1)
         if cat_covs is not None:
             categorical_input = torch.split(cat_covs, 1, dim=1)
         else:
             categorical_input = tuple()
+
+        if transform_batch is not None:
+            batch_index = torch.ones_like(batch_index) * transform_batch
+
         px_, py_, log_pro_back_mean = self.decoder(
             decoder_input, library_gene, batch_index, *categorical_input
         )
@@ -489,9 +500,6 @@ class TOTALVAE(BaseModuleClass):
             py_back_alpha_prior = self.background_pro_alpha
             py_back_beta_prior = torch.exp(self.background_pro_log_beta)
         self.back_mean_prior = Normal(py_back_alpha_prior, py_back_beta_prior)
-
-        if transform_batch is not None:
-            batch_index = torch.ones_like(batch_index) * transform_batch
 
         return dict(
             qz_m=qz_m,

--- a/scvi/module/_vae.py
+++ b/scvi/module/_vae.py
@@ -262,7 +262,14 @@ class VAE(BaseModuleClass):
 
     @auto_move_data
     def generative(
-        self, z, library, batch_index, cont_covs=None, cat_covs=None, y=None
+        self,
+        z,
+        library,
+        batch_index,
+        cont_covs=None,
+        cat_covs=None,
+        y=None,
+        transform_batch=None,
     ):
         """Runs the generative model."""
         # TODO: refactor forward function to not rely on y
@@ -271,6 +278,10 @@ class VAE(BaseModuleClass):
             categorical_input = torch.split(cat_covs, 1, dim=1)
         else:
             categorical_input = tuple()
+
+        if transform_batch is not None:
+            batch_index = torch.ones_like(batch_index) * transform_batch
+
         px_scale, px_r, px_rate, px_dropout = self.decoder(
             self.dispersion, decoder_input, library, batch_index, *categorical_input, y
         )


### PR DESCRIPTION
The way it's implemented right now transforms the batch before it goes through the encoder, which affects totalVI by default.

The desired behavior is to change only before decoding. This bug started with the 0.9 release (pytorch lightning move). 