### PR TITLE
modify DE results dataframe to have columns "group1" and "group2" instead of "comparison"

### DIFF
--- a/scvi/model/base/_utils.py
+++ b/scvi/model/base/_utils.py
@@ -210,6 +210,7 @@ def _de_core(
             )
         if idx1 is None:
             g2 = "Rest" if group2 is None else group2
+            res["comparison"] = "{} vs {}".format(g1, g2)
             res["group1"] = g1
             res["group2"] = g2
         df_results.append(res)

--- a/scvi/model/base/_utils.py
+++ b/scvi/model/base/_utils.py
@@ -210,7 +210,8 @@ def _de_core(
             )
         if idx1 is None:
             g2 = "Rest" if group2 is None else group2
-            res["comparison"] = "{} vs {}".format(g1, g2)
+            res["group1"] = g1
+            res["group2"] = g2
         df_results.append(res)
 
     if temp_key is not None:


### PR DESCRIPTION
I often work with big dataframes of concatenated DE results among arbitrary groups, and so I like to have the names of the group1 and group2 labels in separate columns, instead of joined by a " vs " string, eg `Endothelial vs Fibroblast`.

So I often end up doing:
```
de_df['group1']=de_df['comparison'].str.split('vs', expand=True)[0]
de_df['group2']=de_df['comparison'].str.split('vs', expand=True)[1]
```
 I made a small change so that the de_df result is now in this format already, for example the output from the api_overview tutorial would be:

```
de_df = model.differential_expression(
    groupby="cell_type",
    group1="Endothelial",
    group2="Fibroblast"
)
de_df.head()

Out[16]: 
        proba_de  proba_not_de  ...       group1      group2
ABTB2     0.9646        0.0354  ...  Endothelial  Fibroblast
DANT2     0.9642        0.0358  ...  Endothelial  Fibroblast
TMBIM4    0.9640        0.0360  ...  Endothelial  Fibroblast
LRRTM3    0.9640        0.0360  ...  Endothelial  Fibroblast
CLDN5     0.9638        0.0362  ...  Endothelial  Fibroblast
```

I implemented this as a breaking change, however if it is preferable I can instead make it an additional argument with the default as the old behavior.