### PR TITLE
classifier kwargs and fix adata option for solo

### DIFF
--- a/scvi/external/solo/_model.py
+++ b/scvi/external/solo/_model.py
@@ -11,7 +11,7 @@ from anndata import AnnData
 from pytorch_lightning.callbacks.early_stopping import EarlyStopping
 
 from scvi import _CONSTANTS
-from scvi.data import get_from_registry, setup_anndata
+from scvi.data import get_from_registry, setup_anndata, transfer_anndata_setup
 from scvi.dataloaders import DataSplitter
 from scvi.model import SCVI
 from scvi.model.base import BaseModelClass
@@ -97,6 +97,7 @@ class SOLO(BaseModelClass):
         adata: Optional[AnnData] = None,
         restrict_to_batch: Optional[str] = None,
         doublet_ratio: int = 2,
+        **classifier_kwargs,
     ):
         """
         Instantiate a SOLO model from an scvi model.
@@ -117,6 +118,8 @@ class SOLO(BaseModelClass):
         doublet_ratio
             Ratio of generated doublets to produce relative to number of
             cells in adata or length of indices, if not `None`.
+        **classifier_kwargs
+            Keyword args for :class:`~scvi.module.Classifier`
 
         Returns
         -------
@@ -128,13 +131,18 @@ class SOLO(BaseModelClass):
             "_scvi_batch"
         ]["original_key"]
 
+        if adata is not None:
+            transfer_anndata_setup(orig_adata, adata)
+        else:
+            adata = orig_adata
+
         if restrict_to_batch is not None:
-            batch_mask = orig_adata.obs[orig_batch_key] == restrict_to_batch
+            batch_mask = adata.obs[orig_batch_key] == restrict_to_batch
             if np.sum(batch_mask) == 0:
                 raise ValueError(
                     "Batch category given to restrict_to_batch not found.\n"
                     + "Available categories: {}".format(
-                        orig_adata.obs[orig_batch_key].astype("category").cat.categories
+                        adata.obs[orig_batch_key].astype("category").cat.categories
                     )
                 )
             # indices in adata with restrict_to_batch category
@@ -145,7 +153,7 @@ class SOLO(BaseModelClass):
 
         # anndata with only generated doublets
         doublet_adata = cls.create_doublets(
-            orig_adata, indices=batch_indices, doublet_ratio=doublet_ratio
+            adata, indices=batch_indices, doublet_ratio=doublet_ratio
         )
         # if scvi wasn't trained with batch correction having the
         # zeros here does nothing.
@@ -158,15 +166,13 @@ class SOLO(BaseModelClass):
         give_mean_lib = not scvi_model.module.use_observed_lib_size
 
         # get latent representations and make input anndata
-        latent_rep = scvi_model.get_latent_representation(
-            orig_adata, indices=batch_indices
-        )
+        latent_rep = scvi_model.get_latent_representation(adata, indices=batch_indices)
         lib_size = scvi_model.get_latent_library_size(
-            orig_adata, indices=batch_indices, give_mean=give_mean_lib
+            adata, indices=batch_indices, give_mean=give_mean_lib
         )
         latent_adata = AnnData(np.concatenate([latent_rep, lib_size], axis=1))
         latent_adata.obs[LABELS_KEY] = "singlet"
-        orig_obs_names = orig_adata.obs_names
+        orig_obs_names = adata.obs_names
         latent_adata.obs_names = (
             orig_obs_names[batch_indices]
             if batch_indices is not None
@@ -188,7 +194,7 @@ class SOLO(BaseModelClass):
 
             full_adata = latent_adata.concatenate(doublet_adata)
             setup_anndata(full_adata, labels_key=LABELS_KEY)
-        return cls(full_adata)
+        return cls(full_adata, **classifier_kwargs)
 
     @staticmethod
     def create_doublets(

--- a/scvi/external/solo/_model.py
+++ b/scvi/external/solo/_model.py
@@ -170,7 +170,7 @@ class SOLO(BaseModelClass):
         lib_size = scvi_model.get_latent_library_size(
             adata, indices=batch_indices, give_mean=give_mean_lib
         )
-        latent_adata = AnnData(np.concatenate([latent_rep, lib_size], axis=1))
+        latent_adata = AnnData(np.concatenate([latent_rep, np.log(lib_size)], axis=1))
         latent_adata.obs[LABELS_KEY] = "singlet"
         orig_obs_names = adata.obs_names
         latent_adata.obs_names = (

--- a/scvi/model/base/_rnamixin.py
+++ b/scvi/model/base/_rnamixin.py
@@ -553,7 +553,7 @@ class RNASeqMixin:
             ql_v = outputs["ql_v"]
             library = outputs["library"]
             if give_mean is False:
-                library = library
+                library = torch.exp(library)
             else:
                 library = torch.distributions.LogNormal(ql_m, ql_v.sqrt()).mean
             libraries += [library.cpu()]

--- a/tests/external/test_solo.py
+++ b/tests/external/test_solo.py
@@ -15,6 +15,12 @@ def test_solo(save_path):
     assert "validation_loss" in solo.history.keys()
     solo.predict()
 
+    bdata = synthetic_iid(run_setup_anndata=False)
+    solo = SOLO.from_scvi_model(model, bdata)
+    solo.train(1, check_val_every_n_epoch=1, train_size=0.9)
+    assert "validation_loss" in solo.history.keys()
+    solo.predict()
+
 
 def test_solo_multiple_batch(save_path):
     n_latent = 5


### PR DESCRIPTION
Fixes #1077 

Fixes an issue where `get_latent_library_size` returned samples on the log scale but mean on the linear scale