### PR TITLE
pin pylit to < 1.4

### DIFF
--- a/docs/release_notes/index.rst
+++ b/docs/release_notes/index.rst
@@ -11,6 +11,7 @@ Version 0.12
 .. toctree::
    :maxdepth: 2
 
+   v0.12.1
    v0.12.0
 
 Version 0.11

--- a/docs/release_notes/v0.12.1.rst
+++ b/docs/release_notes/v0.12.1.rst
@@ -3,7 +3,7 @@ New in 0.12.1 (2021-07-29)
 
 Changes
 ~~~~~~~
-- Update Pytorch Lighning version dependency to `>=1.3,<1.4` (`#1104`_).
+- Update Pytorch Lightning version dependency to `>=1.3,<1.4` (`#1104`_).
 
 
 Breaking changes

--- a/docs/release_notes/v0.12.1.rst
+++ b/docs/release_notes/v0.12.1.rst
@@ -19,6 +19,6 @@ Contributors
 .. _`@galenxing`: https://github.com/galenxing
 
 
-.. _`#1059`: https://github.com/YosefLab/scvi-tools/pull/1104
+.. _`#1104`: https://github.com/YosefLab/scvi-tools/pull/1104
 
 

--- a/docs/release_notes/v0.12.1.rst
+++ b/docs/release_notes/v0.12.1.rst
@@ -1,0 +1,24 @@
+New in 0.12.1 (2021-07-29)
+--------------------------
+
+Changes
+~~~~~~~
+- Update Pytorch Lighning version dependency to `>=1.3,<1.4` (`#1104`_).
+
+
+Breaking changes
+~~~~~~~~~~~~~~~~
+None!
+
+Contributors
+~~~~~~~~~~~~
+- `@adamgayoso`_
+- `@galenxing`_
+
+.. _`@adamgayoso`: https://github.com/adamgayoso
+.. _`@galenxing`: https://github.com/galenxing
+
+
+.. _`#1059`: https://github.com/YosefLab/scvi-tools/pull/1104
+
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ pyro-ppl = ">=1.6.0"
 pytest = {version = ">=4.4", optional = true}
 python = ">=3.7.2,<4.0"
 python-igraph = {version = "*", optional = true}
-pytorch-lightning = ">=1.3"
+pytorch-lightning = "~1.3"
 rich = ">=9.1.0"
 scanpy = {version = ">=1.6", optional = true}
 scanpydoc = {version = ">=0.5", optional = true}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ packages = [
   {include = "scvi"},
 ]
 readme = "README.md"
-version = "0.12.0"
+version = "0.12.1"
 
 [tool.poetry.dependencies]
 anndata = ">=0.7.5"


### PR DESCRIPTION
Pytorch Lighting 1.4 causes some major issues, we can pin it for now.

https://python-poetry.org/docs/dependency-specification/#tilde-requirements