### PR TITLE
restrict pytorch lightning <1.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ pyro-ppl = ">=1.6.0"
 pytest = {version = ">=4.4", optional = true}
 python = ">=3.7,<4.0"
 python-igraph = {version = "*", optional = true}
-pytorch-lightning = "~1.4.1"
+pytorch-lightning = "~1.3"
 rich = ">=9.1.0"
 scanpy = {version = ">=1.6", optional = true}
 scanpydoc = {version = ">=0.5", optional = true}


### PR DESCRIPTION
The changes made in #1103 are still compatible with lightning 1.3.x so we should just upper bound the version for now as per issue #1143 