### PR TITLE
Bug fix in pyromixin for posterior sampling

### DIFF
--- a/scvi/model/base/_pyromixin.py
+++ b/scvi/model/base/_pyromixin.py
@@ -236,7 +236,7 @@ class PyroSampleMixin:
         dictionary {variable_name: [array with samples in 0 dimension]}
         """
         samples = self._get_one_posterior_sample(
-            args, kwargs, return_sites=return_sites, sample_observed=return_observed
+            args, kwargs, return_sites=return_sites, return_observed=return_observed
         )
         samples = {k: [v] for k, v in samples.items()}
 
@@ -249,7 +249,7 @@ class PyroSampleMixin:
 
             # generate new sample
             samples_ = self._get_one_posterior_sample(
-                args, kwargs, return_sites=return_sites, sample_observed=return_observed
+                args, kwargs, return_sites=return_sites, return_observed=return_observed
             )
 
             # add new sample

--- a/scvi/model/base/_pyromixin.py
+++ b/scvi/model/base/_pyromixin.py
@@ -297,6 +297,7 @@ class PyroSampleMixin:
                 and not isinstance(
                     site.get("fn", None), poutine.subsample_messenger._Subsample
                 )  # don't save plates
+            )
             if any(f.name == plate_name for f in site["cond_indep_stack"])
         }
 

--- a/scvi/model/base/_pyromixin.py
+++ b/scvi/model/base/_pyromixin.py
@@ -344,9 +344,7 @@ class PyroSampleMixin:
             self.to_device(device)
 
             if i == 0:
-                sample_observed = sample_kwargs["sample_observed"]
-                if sample_observed is None:
-                    sample_observed = False
+                sample_observed = getattr(sample_kwargs, "sample_observed", False)
                 obs_plate_sites = self._get_obs_plate_sites(
                     args, kwargs, sample_observed=sample_observed
                 )

--- a/scvi/model/base/_pyromixin.py
+++ b/scvi/model/base/_pyromixin.py
@@ -168,7 +168,7 @@ class PyroSampleMixin:
         args
             arguments to model and guide
         kwargs
-            arguments to model and guide 
+            arguments to model and guide
         return_sites
             List of variables for which to generate posterior samples, defaults to all variables.
         return_observed
@@ -222,7 +222,7 @@ class PyroSampleMixin:
         args
             arguments to model and guide
         kwargs
-            keyword arguments to model and guide  
+            keyword arguments to model and guide
         return_sites
             List of variables for which to generate posterior samples, defaults to all variables.
         return_observed
@@ -271,10 +271,10 @@ class PyroSampleMixin:
             return obs_plate_sites
 
     def _get_obs_plate_sites(
-        self, 
-        args: Optional[list], 
+        self,
+        args: Optional[list],
         kwargs: Optional[dict],
-        return_observed: bool = False
+        return_observed: bool = False,
     ):
         """
         Automatically guess which model sites belong to observation/minibatch plate.
@@ -286,7 +286,7 @@ class PyroSampleMixin:
         args
             Arguments to the model.
         kwargs
-            Keyword arguments to the model.   
+            Keyword arguments to the model.
         return_observed
             Record samples of observed variables.
 

--- a/scvi/model/base/_pyromixin.py
+++ b/scvi/model/base/_pyromixin.py
@@ -158,7 +158,7 @@ class PyroSampleMixin:
         args,
         kwargs,
         return_sites: Optional[list] = None,
-        sample_observed: bool = False,
+        return_observed: bool = False,
     ):
         """
         Get one sample from posterior distribution.
@@ -168,7 +168,11 @@ class PyroSampleMixin:
         args
             arguments to model and guide
         kwargs
-            arguments to model and guide
+            arguments to model and guide 
+        return_sites
+            List of variables for which to generate posterior samples, defaults to all variables.
+        return_observed
+            Record samples of observed variables.
 
         Returns
         -------
@@ -189,7 +193,7 @@ class PyroSampleMixin:
                 )  # selected in return_sites list
                 and (
                     (
-                        (not site.get("is_observed", True)) or sample_observed
+                        (not site.get("is_observed", True)) or return_observed
                     )  # don't save observed unless requested
                     or (site.get("infer", False).get("_deterministic", False))
                 )  # unless it is deterministic
@@ -218,7 +222,11 @@ class PyroSampleMixin:
         args
             arguments to model and guide
         kwargs
-            keyword arguments to model and guide
+            keyword arguments to model and guide  
+        return_sites
+            List of variables for which to generate posterior samples, defaults to all variables.
+        return_observed
+            Record samples of observed variables.
         show_progress
             show progress bar
 
@@ -262,7 +270,12 @@ class PyroSampleMixin:
         else:
             return obs_plate_sites
 
-    def _get_obs_plate_sites(self, args, kwargs, sample_observed):
+    def _get_obs_plate_sites(
+        self, 
+        args: Optional[list], 
+        kwargs: Optional[dict],
+        return_observed: bool = False
+    ):
         """
         Automatically guess which model sites belong to observation/minibatch plate.
 
@@ -273,7 +286,9 @@ class PyroSampleMixin:
         args
             Arguments to the model.
         kwargs
-            Keyword arguments to the model.
+            Keyword arguments to the model.   
+        return_observed
+            Record samples of observed variables.
 
         Returns
         -------
@@ -290,7 +305,7 @@ class PyroSampleMixin:
                 (site["type"] == "sample")  # sample statement
                 and (
                     (
-                        (not site.get("is_observed", True)) or sample_observed
+                        (not site.get("is_observed", True)) or return_observed
                     )  # don't save observed unless requested
                     or (site.get("infer", False).get("_deterministic", False))
                 )  # unless it is deterministic
@@ -344,9 +359,9 @@ class PyroSampleMixin:
             self.to_device(device)
 
             if i == 0:
-                sample_observed = getattr(sample_kwargs, "sample_observed", False)
+                return_observed = getattr(sample_kwargs, "return_observed", False)
                 obs_plate_sites = self._get_obs_plate_sites(
-                    args, kwargs, sample_observed=sample_observed
+                    args, kwargs, return_observed=return_observed
                 )
                 if len(obs_plate_sites) == 0:
                     # if no local variables - don't sample
@@ -420,7 +435,7 @@ class PyroSampleMixin:
         ----------
         num_samples
             Number of posterior samples to generate.
-        return_site
+        return_sites
             List of variables for which to generate posterior samples, defaults to all variables.
         use_gpu
             Load model on default GPU if available (if None or True),
@@ -430,7 +445,7 @@ class PyroSampleMixin:
         return_observed
             Return observed sites/variables? Observed count matrix can be very large so not returned by default.
         return_samples
-            Return samples in addition to sample mean, 5%/95% quantile and SD?
+            Return all generated posterior samples in addition to sample mean, 5%/95% quantile and SD?
         summary_fun
              a dict in the form {"means": np.mean, "std": np.std} which specifies posterior distribution
              summaries to compute and which names to use. See below for default returns.

--- a/scvi/model/base/_pyromixin.py
+++ b/scvi/model/base/_pyromixin.py
@@ -272,8 +272,8 @@ class PyroSampleMixin:
 
     def _get_obs_plate_sites(
         self,
-        args: Optional[list],
-        kwargs: Optional[dict],
+        args: list,
+        kwargs: dict,
         return_observed: bool = False,
     ):
         """

--- a/scvi/model/base/_pyromixin.py
+++ b/scvi/model/base/_pyromixin.py
@@ -347,7 +347,9 @@ class PyroSampleMixin:
                 sample_observed = sample_kwargs["sample_observed"]
                 if sample_observed is None:
                     sample_observed = False
-                obs_plate_sites = self._get_obs_plate_sites(args, kwargs, sample_observed=sample_observed)
+                obs_plate_sites = self._get_obs_plate_sites(
+                    args, kwargs, sample_observed=sample_observed
+                )
                 if len(obs_plate_sites) == 0:
                     # if no local variables - don't sample
                     break


### PR DESCRIPTION
The method `._get_obs_plate_sites()` should discard observed variables (unless requested otherwise) and plates. Current code always performs posterior sampling even if unobserved local variables do not exist in the model, e.i. code never enters this statement:
```
if len(obs_plate_sites) == 0:
    # if no local variables - don't sample
    break
```

This PR addresses the issue by adding a check for observed and plates.