### PR TITLE
LDA logistic normal mean fix

### DIFF
--- a/scvi/model/_amortizedlda.py
+++ b/scvi/model/_amortizedlda.py
@@ -93,17 +93,17 @@ class AmortizedLDA(PyroSviTrainMixin, BaseModelClass):
 
         self.init_params_ = self._get_init_params(locals())
 
-    def get_gene_by_topic(self, give_mean=True) -> pd.DataFrame:
+    def get_gene_by_topic(self, n_samples=5000) -> pd.DataFrame:
         """
-        Gets the gene by topic matrix.
+        Gets a Monte-Carlo estimate of the expectation of the gene by topic matrix.
 
         Parameters
         ----------
         adata
             AnnData to transform. If None, returns the gene by topic matrix for
             the source AnnData.
-        give_mean
-            Give mean of distribution if True or sample from it.
+        n_samples
+            Number of samples to take for the Monte-Carlo estimate of the mean.
 
         Returns
         -------
@@ -111,7 +111,7 @@ class AmortizedLDA(PyroSviTrainMixin, BaseModelClass):
         """
         self._check_if_trained(warn=False)
 
-        topic_by_gene = self.module.topic_by_gene(give_mean=give_mean)
+        topic_by_gene = self.module.topic_by_gene(n_samples=n_samples)
 
         return pd.DataFrame(
             data=topic_by_gene.numpy().T,
@@ -124,7 +124,7 @@ class AmortizedLDA(PyroSviTrainMixin, BaseModelClass):
         adata: Optional[AnnData] = None,
         indices: Optional[Sequence[int]] = None,
         batch_size: Optional[int] = None,
-        give_mean: bool = True,
+        n_samples: int = 5000,
     ) -> pd.DataFrame:
         """
         Converts a count matrix to an inferred topic distribution.
@@ -138,8 +138,8 @@ class AmortizedLDA(PyroSviTrainMixin, BaseModelClass):
             Indices of cells in adata to use. If `None`, all cells are used.
         batch_size
             Minibatch size for data loading into model. Defaults to `scvi.settings.batch_size`.
-        give_mean
-            Give mean of distribution or sample from it.
+        n_samples
+            Number of samples to take for the Monte-Carlo estimate of the mean.
 
         Returns
         -------
@@ -155,7 +155,7 @@ class AmortizedLDA(PyroSviTrainMixin, BaseModelClass):
         for tensors in dl:
             x = tensors[_CONSTANTS.X_KEY]
             transformed_xs.append(
-                self.module.get_topic_distribution(x, give_mean=give_mean)
+                self.module.get_topic_distribution(x, n_samples=n_samples)
             )
         transformed_x = torch.cat(transformed_xs).numpy()
 

--- a/scvi/module/_amortizedlda.py
+++ b/scvi/module/_amortizedlda.py
@@ -300,13 +300,13 @@ class AmortizedLDAPyroModule(PyroBaseModuleClass):
         )
         return torch.mean(
             F.softmax(
-                torch.normal(
-                    topic_gene_posterior_mu.unsqueeze(2).repeat(1, 1, n_samples),
-                    topic_gene_posterior_sigma.unsqueeze(2).repeat(1, 1, n_samples),
-                ),
-                dim=1,
+                dist.Normal(
+                    topic_gene_posterior_mu,
+                    topic_gene_posterior_sigma,
+                ).sample(sample_shape=torch.Size((n_samples,))),
+                dim=2,
             ),
-            dim=2,
+            dim=0,
         )
 
     @auto_move_data
@@ -335,13 +335,12 @@ class AmortizedLDAPyroModule(PyroBaseModuleClass):
         cell_topic_dist_sigma = F.softplus(cell_topic_dist_sigma.detach().cpu())
         return torch.mean(
             F.softmax(
-                torch.normal(
-                    cell_topic_dist_mu.unsqueeze(2).repeat(1, 1, n_samples),
-                    cell_topic_dist_sigma.unsqueeze(2).repeat(1, 1, n_samples),
+                dist.Normal(cell_topic_dist_mu, cell_topic_dist_sigma).sample(
+                    sample_shape=torch.Size((n_samples,))
                 ),
-                dim=1,
+                dim=2,
             ),
-            dim=2,
+            dim=0,
         )
 
     @auto_move_data


### PR DESCRIPTION
Fixes #1168 

`get_gene_by_topic` and `get_latent_representation` now both are stochastic and take n_samples as an optional argument defaulting to 5000. We need to give a MC estimate of the mean of the logistic normal since there is no analytic solution. What was implemented before was just incorrect.

Tested in benchmarking colab notebook: https://colab.research.google.com/drive/1Iq_drlBTLadM8KJtZwIs96RdzG8MmEFA?authuser=1#scrollTo=R0LTgkF8gR_a