### PR TITLE
Fix bug in overriding missing protein handling in totalVI

### DIFF
--- a/scvi/model/_totalvi.py
+++ b/scvi/model/_totalvi.py
@@ -6,6 +6,7 @@ from typing import Dict, Iterable, List, Optional, Sequence, Tuple, TypeVar, Uni
 
 import numpy as np
 import pandas as pd
+from pandas.core.frame import DataFrame
 import torch
 from anndata import AnnData
 
@@ -1112,6 +1113,7 @@ def _get_totalvi_protein_priors(adata, batch_mask, n_cells=100):
 
     warnings.filterwarnings("error")
 
+    logger.info("Computing empirical prior initialization for protein background.")
     batch = get_from_registry(adata, _CONSTANTS.BATCH_KEY).ravel()
     cats = adata.uns["_scvi"]["categorical_mappings"]["_scvi_batch"]["mapping"]
     codes = np.arange(len(cats))
@@ -1125,8 +1127,10 @@ def _get_totalvi_protein_priors(adata, batch_mask, n_cells=100):
             batch_avg_mus.append(0)
             batch_avg_scales.append(1)
             continue
-        pro_exp = get_from_registry(adata, _CONSTANTS.PROTEIN_EXP_KEY)[batch == b]
-
+        pro_exp = get_from_registry(adata, _CONSTANTS.PROTEIN_EXP_KEY)
+        if isinstance(pro_exp, pd.DataFrame):
+            pro_exp = np.asarray(pro_exp)
+        pro_exp = pro_exp[batch == b]
         # non missing
         if batch_mask is not None:
             pro_exp = pro_exp[:, batch_mask[b]]

--- a/scvi/model/_totalvi.py
+++ b/scvi/model/_totalvi.py
@@ -6,9 +6,9 @@ from typing import Dict, Iterable, List, Optional, Sequence, Tuple, TypeVar, Uni
 
 import numpy as np
 import pandas as pd
-from pandas.core.frame import DataFrame
 import torch
 from anndata import AnnData
+from pandas.core.frame import DataFrame
 
 from scvi import _CONSTANTS
 from scvi._compat import Literal

--- a/scvi/model/_totalvi.py
+++ b/scvi/model/_totalvi.py
@@ -122,8 +122,11 @@ class TOTALVI(RNASeqMixin, VAEMixin, ArchesMixin, BaseModelClass):
                 + "to override this behavior."
             )
             logger.info(info_msg)
+            self._use_adversarial_classifier = True
         else:
             batch_mask = None
+            self._use_adversarial_classifier = False
+
         emp_prior = (
             empirical_protein_background_prior
             if empirical_protein_background_prior is not None
@@ -235,10 +238,7 @@ class TOTALVI(RNASeqMixin, VAEMixin, ArchesMixin, BaseModelClass):
             Other keyword args for :class:`~scvi.train.Trainer`.
         """
         if adversarial_classifier is None:
-            imputation = (
-                True if "totalvi_batch_mask" in self.scvi_setup_dict_.keys() else False
-            )
-            adversarial_classifier = True if imputation else False
+            adversarial_classifier = self._use_adversarial_classifier
         n_steps_kl_warmup = (
             n_steps_kl_warmup
             if n_steps_kl_warmup is not None

--- a/scvi/model/_totalvi.py
+++ b/scvi/model/_totalvi.py
@@ -114,14 +114,14 @@ class TOTALVI(RNASeqMixin, VAEMixin, ArchesMixin, BaseModelClass):
             and not override_missing_proteins
         ):
             batch_mask = self.scvi_setup_dict_["totalvi_batch_mask"]
-            info_msg = (
+            msg = (
                 "Some proteins have all 0 counts in some batches. "
-                + "These proteins will be treated as missing; however, "
+                + "These proteins will be treated as missing measurements; however, "
                 + "this can occur due to experimental design/biology. "
                 + "Reinitialize the model with `override_missing_proteins=True`,"
                 + "to override this behavior."
             )
-            logger.info(info_msg)
+            warnings.warn(msg, UserWarning)
             self._use_adversarial_classifier = True
         else:
             batch_mask = None

--- a/scvi/model/_totalvi.py
+++ b/scvi/model/_totalvi.py
@@ -1181,10 +1181,11 @@ def _get_totalvi_protein_priors(adata, batch_mask, n_cells=100):
         batch_avg_scales.append(batch_avg_scale)
 
     # repeat prior for each protein
+    n_proteins = get_from_registry(adata, _CONSTANTS.PROTEIN_EXP_KEY).shape[1]
     batch_avg_mus = np.array(batch_avg_mus, dtype=np.float32).reshape(1, -1)
     batch_avg_scales = np.array(batch_avg_scales, dtype=np.float32).reshape(1, -1)
-    batch_avg_mus = np.tile(batch_avg_mus, (pro_exp.shape[1], 1))
-    batch_avg_scales = np.tile(batch_avg_scales, (pro_exp.shape[1], 1))
+    batch_avg_mus = np.tile(batch_avg_mus, (n_proteins, 1))
+    batch_avg_scales = np.tile(batch_avg_scales, (n_proteins, 1))
 
     warnings.resetwarnings()
 

--- a/scvi/model/_totalvi.py
+++ b/scvi/model/_totalvi.py
@@ -8,7 +8,6 @@ import numpy as np
 import pandas as pd
 import torch
 from anndata import AnnData
-from pandas.core.frame import DataFrame
 
 from scvi import _CONSTANTS
 from scvi._compat import Literal

--- a/scvi/module/_totalvae.py
+++ b/scvi/module/_totalvae.py
@@ -609,7 +609,8 @@ class TOTALVAE(BaseModuleClass):
             kl_div_back_pro = torch.zeros_like(kl_div_back_pro_full)
             kl_div_back_pro.masked_scatter_(
                 pro_batch_mask_minibatch.bool(), kl_div_back_pro_full
-            ).sum(dim=1)
+            )
+            kl_div_back_pro = kl_div_back_pro.sum(dim=1)
         else:
             kl_div_back_pro = kl_div_back_pro_full.sum(dim=1)
         loss = torch.mean(

--- a/scvi/module/_totalvae.py
+++ b/scvi/module/_totalvae.py
@@ -606,9 +606,10 @@ class TOTALVAE(BaseModuleClass):
             Normal(py_["back_alpha"], py_["back_beta"]), self.back_mean_prior
         )
         if pro_batch_mask_minibatch is not None:
-            kl_div_back_pro = (pro_batch_mask_minibatch * kl_div_back_pro_full).sum(
-                dim=1
-            )
+            kl_div_back_pro = torch.zeros_like(kl_div_back_pro_full)
+            kl_div_back_pro.masked_scatter_(
+                pro_batch_mask_minibatch.bool(), kl_div_back_pro_full
+            ).sum(dim=1)
         else:
             kl_div_back_pro = kl_div_back_pro_full.sum(dim=1)
         loss = torch.mean(


### PR DESCRIPTION
1. Changes warning message
2. Changes empirical prior initialization by correctly now ignoring proteins that are missing