### PR TITLE
Copy the scvi state dict during `SCANVI` initialization to prevent it from being overwritten within `scvi_model`

### DIFF
--- a/scvi/model/_scanvi.py
+++ b/scvi/model/_scanvi.py
@@ -200,7 +200,7 @@ class SCANVI(RNASeqMixin, VAEMixin, ArchesMixin, BaseModelClass):
         scanvi_model = cls(
             adata, unlabeled_category, **non_kwargs, **kwargs, **scanvi_kwargs
         )
-        scvi_state_dict = scvi_model.module.state_dict()
+        scvi_state_dict = scvi_model.module.state_dict().copy()
         scanvi_model.module.load_state_dict(scvi_state_dict, strict=False)
         scanvi_model.was_pretrained = True
 

--- a/scvi/model/_scanvi.py
+++ b/scvi/model/_scanvi.py
@@ -200,7 +200,7 @@ class SCANVI(RNASeqMixin, VAEMixin, ArchesMixin, BaseModelClass):
         scanvi_model = cls(
             adata, unlabeled_category, **non_kwargs, **kwargs, **scanvi_kwargs
         )
-        scvi_state_dict = scvi_model.module.state_dict().copy()
+        scvi_state_dict = scvi_model.module.state_dict()
         scanvi_model.module.load_state_dict(scvi_state_dict, strict=False)
         scanvi_model.was_pretrained = True
 

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -636,6 +636,12 @@ def test_scanvi(save_path):
     m = scvi.model.SCVI(a, use_observed_lib_size=False)
     a2 = scvi.data.synthetic_iid()
     scanvi_model = scvi.model.SCANVI.from_scvi_model(m, "label_0", adata=a2)
+    # make sure the state_dicts are different objects for the two models
+    assert scanvi_model.module.state_dict() is not m.module.state_dict()
+    scanvi_pxr = scanvi_model.module.state_dict().get("px_r", None)
+    scvi_pxr = m.module.state_dict().get("px_r", None)
+    assert scanvi_pxr is not None and scvi_pxr is not None
+    assert scanvi_pxr is not scvi_pxr
     scanvi_model = scvi.model.SCANVI.from_scvi_model(
         m, "label_0", use_labels_groups=False
     )


### PR DESCRIPTION
Fixes #1283