### PR TITLE
Save/Load with saved setup inputs

### DIFF
--- a/scvi/data/anndata/__init__.py
+++ b/scvi/data/anndata/__init__.py
@@ -1,5 +1,5 @@
+from ._manager import AnnDataManager
 from ._utils import register_tensor_from_anndata, setup_anndata, transfer_anndata_setup
-from .manager import AnnDataManager
 
 __all__ = [
     "setup_anndata",

--- a/scvi/data/anndata/__init__.py
+++ b/scvi/data/anndata/__init__.py
@@ -5,6 +5,5 @@ __all__ = [
     "setup_anndata",
     "transfer_anndata_setup",
     "register_tensor_from_anndata",
-    "get_from_registry",
     "AnnDataManager",
 ]

--- a/scvi/data/anndata/__init__.py
+++ b/scvi/data/anndata/__init__.py
@@ -1,7 +1,13 @@
-from ._utils import register_tensor_from_anndata, setup_anndata, transfer_anndata_setup
+from ._utils import (
+    get_from_registry,
+    register_tensor_from_anndata,
+    setup_anndata,
+    transfer_anndata_setup,
+)
 
 __all__ = [
     "setup_anndata",
     "transfer_anndata_setup",
     "register_tensor_from_anndata",
+    "get_from_registry",
 ]

--- a/scvi/data/anndata/_compat.py
+++ b/scvi/data/anndata/_compat.py
@@ -77,7 +77,10 @@ def registry_from_setup_dict(setup_dict: dict) -> dict:
 
 
 @deprecated(
-    extra="The save format of models has been updated. Please update your saved model files accordingly."
+    extra=(
+        "The save format of models has been updated. Please update your saved model files accordingly. "
+        "Backwards compatibility with be removed in v1.0."
+    )
 )
 def manager_from_setup_dict(
     cls, adata: AnnData, setup_dict: dict, **transfer_kwargs

--- a/scvi/data/anndata/_compat.py
+++ b/scvi/data/anndata/_compat.py
@@ -4,13 +4,13 @@ from anndata import AnnData
 from sklearn.utils import deprecated
 
 from . import _constants
+from ._manager import AnnDataManager
 from .fields import (
     CategoricalJointObsField,
     CategoricalObsField,
     LayerField,
     NumericalJointObsField,
 )
-from .manager import AnnDataManager
 
 
 def registry_from_setup_dict(setup_dict: dict) -> dict:
@@ -86,11 +86,11 @@ def manager_from_setup_dict(
     cls, adata: AnnData, setup_dict: dict, **transfer_kwargs
 ) -> AnnDataManager:
     """
-    Creates an AnnDataManager given only a scvi-tools setup dictionary.
+    Creates an :class:`~scvi.data.anndata.AnnDataManager` given only a scvi-tools setup dictionary.
 
     Only to be used for backwards compatibility when loading setup dictionaries for models.
-    Infers the AnnDataField instances used to define the AnnDataManager instance,
-    then uses the `AnnDataManager.transfer_setup(...)` method to register the new AnnData object.
+    Infers the AnnDataField instances used to define the :class:`~scvi.data.anndata.AnnDataManager` instance,
+    then uses the :meth:`~scvi.data.anndata.AnnDataManager.transfer_setup` method to register the new AnnData object.
 
     Parameters
     ----------
@@ -137,11 +137,11 @@ def manager_from_setup_dict(
                 f"Backwards compatibility for attribute {attr_name} is not implemented yet."
             )
         fields.append(field)
-    setup_inputs = {
+    setup_method_args = {
         _constants._MODEL_NAME_KEY: cls.__name__,
         _constants._SETUP_KWARGS_KEY: setup_kwargs,
     }
-    adata_manager = AnnDataManager(fields=fields, setup_inputs=setup_inputs)
+    adata_manager = AnnDataManager(fields=fields, setup_method_args=setup_method_args)
 
     source_registry = registry_from_setup_dict(setup_dict)
     adata_manager.register_fields(

--- a/scvi/data/anndata/_compat.py
+++ b/scvi/data/anndata/_compat.py
@@ -1,6 +1,7 @@
 from copy import deepcopy
 
 from anndata import AnnData
+from sklearn.utils import deprecated
 
 from . import _constants
 from .fields import (
@@ -75,6 +76,9 @@ def registry_from_setup_dict(setup_dict: dict) -> dict:
     return registry
 
 
+@deprecated(
+    extra="The save format of models has been updated. Please update your saved model files accordingly."
+)
 def manager_from_setup_dict(
     adata: AnnData, setup_dict: dict, **transfer_kwargs
 ) -> AnnDataManager:
@@ -94,7 +98,7 @@ def manager_from_setup_dict(
     **kwargs
         Keyword arguments to modify transfer behavior.
     """
-    source_adata_manager = AnnDataManager()
+    adata_manager = AnnDataManager()
     data_registry = setup_dict[_constants._DATA_REGISTRY_KEY]
     categorical_mappings = setup_dict["categorical_mappings"]
     for registry_key, adata_mapping in data_registry.items():
@@ -123,8 +127,8 @@ def manager_from_setup_dict(
             raise NotImplementedError(
                 f"Backwards compatibility for attribute {attr_name} is not implemented yet."
             )
-        source_adata_manager.add_field(field)
+        adata_manager.add_field(field)
     source_registry = registry_from_setup_dict(setup_dict)
-    return source_adata_manager.transfer_setup(
+    return adata_manager.register_fields(
         adata, source_registry=source_registry, **transfer_kwargs
     )

--- a/scvi/data/anndata/_constants.py
+++ b/scvi/data/anndata/_constants.py
@@ -8,11 +8,13 @@ _SCVI_UUID_KEY = "_scvi_uuid"
 _SOURCE_SCVI_UUID_KEY = "_source_scvi_uuid"
 
 #############################
-# scVI Setup Dict Constants #
+# scVI Registry Constants #
 #############################
 
 _SETUP_DICT_KEY = "_scvi"
 _SCVI_VERSION_KEY = "scvi_version"
+_MODEL_NAME_KEY = "model_name"
+_SETUP_KWARGS_KEY = "setup_kwargs"
 _FIELD_REGISTRIES_KEY = "field_registries"
 _DATA_REGISTRY_KEY = "data_registry"
 _STATE_REGISTRY_KEY = "state_registry"

--- a/scvi/data/anndata/_manager.py
+++ b/scvi/data/anndata/_manager.py
@@ -102,7 +102,7 @@ class AnnDataManager:
         adata
             AnnData object to be registered.
         source_registry
-            Registry created after registering an AnnData using an AnnDataManager object.
+            Registry created after registering an AnnData using an :class:`~scvi.data.anndata.AnnDataManager` object.
         """
         assert (
             self.adata is None
@@ -208,7 +208,7 @@ class AnnDataManager:
 
     @property
     def setup_inputs(self) -> dict:
-        """Returns the setup inputs, including the model name, that were used to initialize this AnnDataManager instance."""
+        """Returns the setup inputs, including the model name, that were used to initialize this :class:`~scvi.data.anndata.AnnDataManager` instance."""
         return {
             k: v
             for k, v in self.registry.items()

--- a/scvi/data/anndata/_manager.py
+++ b/scvi/data/anndata/_manager.py
@@ -208,7 +208,7 @@ class AnnDataManager:
         return summary_stats
 
     @property
-    def setup_method_arguments(self) -> dict:
+    def setup_method_args(self) -> dict:
         """
         Returns the ``setup_anndata`` method arguments used to initialize this :class:`~scvi.data.anndata.AnnDataManager` instance.
 

--- a/scvi/data/anndata/fields/_base_field.py
+++ b/scvi/data/anndata/fields/_base_field.py
@@ -82,7 +82,7 @@ class BaseAnnDataField(ABC):
         Parameters
         ----------
         state_registry
-            state_registry dictionary created after registering an AnnData using an AnnDataManager object.
+            state_registry dictionary created after registering an AnnData using an :class:`~scvi.data.anndata.AnnDataManager` object.
         adata_target
             AnnData object that is being registered.
         **kwargs

--- a/scvi/data/anndata/manager.py
+++ b/scvi/data/anndata/manager.py
@@ -208,6 +208,7 @@ class AnnDataManager:
 
     @property
     def setup_inputs(self) -> dict:
+        """Returns the setup inputs, including the model name, that were used to initialize this AnnDataManager instance."""
         return {
             k: v
             for k, v in self.registry.items()

--- a/scvi/data/anndata/manager.py
+++ b/scvi/data/anndata/manager.py
@@ -145,9 +145,7 @@ class AnnDataManager:
         self._assign_uuid()
         self._assign_source_uuid(source_registry)
 
-    def transfer_setup(
-        self, adata_target: AnnData, source_registry: Optional[dict] = None, **kwargs
-    ) -> AnnDataManager:
+    def transfer_setup(self, adata_target: AnnData, **kwargs) -> AnnDataManager:
         """
         Transfers an existing setup to each field associated with this instance with the target AnnData object.
 
@@ -158,20 +156,12 @@ class AnnDataManager:
         ----------
         adata_target
             AnnData object to be registered.
-        source_registry
-            Registry dictionary created after registering an AnnData using an AnnDataManager object.
         """
-        if source_registry is None and self.adata is None:
-            raise AssertionError(
-                "Requires either source registry or a registered AnnData object."
-            )
-
-        if source_registry is None:
-            source_registry = self.registry
+        self._assert_anndata_registered()
 
         fields = self.fields
         new_adata_manager = self.__class__(fields)
-        new_adata_manager.register_fields(adata_target, source_registry, **kwargs)
+        new_adata_manager.register_fields(adata_target, self.registry, **kwargs)
         return new_adata_manager
 
     def get_adata_uuid(self) -> UUID:

--- a/scvi/dataloaders/_ann_dataloader.py
+++ b/scvi/dataloaders/_ann_dataloader.py
@@ -6,7 +6,7 @@ import numpy as np
 import torch
 from torch.utils.data import DataLoader
 
-from scvi.data.anndata.manager import AnnDataManager
+from scvi.data.anndata import AnnDataManager
 
 from ._anntorchdataset import AnnTorchDataset
 

--- a/scvi/dataloaders/_ann_dataloader.py
+++ b/scvi/dataloaders/_ann_dataloader.py
@@ -93,7 +93,7 @@ class AnnDataLoader(DataLoader):
     Parameters
     ----------
     adata_manager
-        AnnDataManager object that has been created via setup_anndata.
+        :class:`~scvi.data.anndata.AnnDataManager` object that has been created via ``setup_anndata``.
     shuffle
         Whether the data should be shuffled
     indices
@@ -101,9 +101,9 @@ class AnnDataLoader(DataLoader):
     batch_size
         minibatch size to load each iteration
     data_and_attributes
-        Dictionary with keys representing keys in data registry (`adata_manager.data_registry`)
+        Dictionary with keys representing keys in data registry (``adata_manager.data_registry``)
         and value equal to desired numpy loading type (later made into torch tensor).
-        If `None`, defaults to all registered data.
+        If ``None``, defaults to all registered data.
     data_loader_kwargs
         Keyword arguments for :class:`~torch.utils.data.DataLoader`
     """

--- a/scvi/dataloaders/_anntorchdataset.py
+++ b/scvi/dataloaders/_anntorchdataset.py
@@ -7,7 +7,7 @@ import pandas as pd
 from anndata._core.sparse_dataset import SparseDataset
 from torch.utils.data import Dataset
 
-from scvi.data.anndata.manager import AnnDataManager
+from scvi.data.anndata import AnnDataManager
 
 logger = logging.getLogger(__name__)
 

--- a/scvi/dataloaders/_concat_dataloader.py
+++ b/scvi/dataloaders/_concat_dataloader.py
@@ -4,7 +4,7 @@ from typing import List, Optional, Union
 import numpy as np
 from torch.utils.data import DataLoader
 
-from scvi.data.anndata.manager import AnnDataManager
+from scvi.data.anndata import AnnDataManager
 
 from ._ann_dataloader import AnnDataLoader
 

--- a/scvi/dataloaders/_concat_dataloader.py
+++ b/scvi/dataloaders/_concat_dataloader.py
@@ -16,7 +16,7 @@ class ConcatDataLoader(DataLoader):
     Parameters
     ----------
     adata_manager
-        AnnDataManager object that has been created via setup_anndata.
+        :class:`~scvi.data.anndata.AnnDataManager` object that has been created via ``setup_anndata``.
     indices_list
         List where each element is a list of indices in the adata to load
     shuffle
@@ -24,9 +24,9 @@ class ConcatDataLoader(DataLoader):
     batch_size
         minibatch size to load each iteration
     data_and_attributes
-        Dictionary with keys representing keys in data registry (`adata_manager.data_registry`)
+        Dictionary with keys representing keys in data registry (``adata_manager.data_registry``)
         and value equal to desired numpy loading type (later made into torch tensor).
-        If `None`, defaults to all registered data.
+        If ``None``, defaults to all registered data.
     data_loader_kwargs
         Keyword arguments for :class:`~torch.utils.data.DataLoader`
     """

--- a/scvi/dataloaders/_data_splitting.py
+++ b/scvi/dataloaders/_data_splitting.py
@@ -61,7 +61,7 @@ class DataSplitter(pl.LightningDataModule):
     Parameters
     ----------
     adata_manager
-        AnnDataManager object that has been created via setup_anndata.
+        :class:`~scvi.data.anndata.AnnDataManager` object that has been created via ``setup_anndata``.
     train_size
         float, or None (default is 0.9)
     validation_size
@@ -166,7 +166,7 @@ class SemiSupervisedDataSplitter(pl.LightningDataModule):
     Parameters
     ----------
     adata_manager
-        AnnDataManager object that has been created via setup_anndata.
+        :class:`~scvi.data.anndata.AnnDataManager` object that has been created via ``setup_anndata``.
     unlabeled_category
         Category to treat as unlabeled
     train_size
@@ -336,7 +336,7 @@ class DeviceBackedDataSplitter(DataSplitter):
     Parameters
     ----------
     adata_manager
-        AnnDataManager object that has been created via setup_anndata.
+        :class:`~scvi.data.anndata.AnnDataManager` object that has been created via ``setup_anndata``.
     train_size
         float, or None (default is 0.9)
     validation_size

--- a/scvi/dataloaders/_data_splitting.py
+++ b/scvi/dataloaders/_data_splitting.py
@@ -7,7 +7,7 @@ import torch
 from torch.utils.data import DataLoader, Dataset
 
 from scvi import _CONSTANTS, settings
-from scvi.data.anndata.manager import AnnDataManager
+from scvi.data.anndata import AnnDataManager
 from scvi.dataloaders._ann_dataloader import AnnDataLoader, BatchSampler
 from scvi.dataloaders._semi_dataloader import SemiSupervisedDataLoader
 from scvi.model._utils import parse_use_gpu_arg

--- a/scvi/dataloaders/_semi_dataloader.py
+++ b/scvi/dataloaders/_semi_dataloader.py
@@ -15,7 +15,7 @@ class SemiSupervisedDataLoader(ConcatDataLoader):
     Parameters
     ----------
     adata_manager
-        AnnDataManager object that has been created via setup_anndata.
+        :class:`~scvi.data.anndata.AnnDataManager` object that has been created via ``setup_anndata``.
     unlabeled_category
         Category to treat as unlabeled
     n_samples_per_label

--- a/scvi/dataloaders/_semi_dataloader.py
+++ b/scvi/dataloaders/_semi_dataloader.py
@@ -3,7 +3,7 @@ from typing import List, Optional, Union
 import numpy as np
 
 from scvi import _CONSTANTS
-from scvi.data.anndata.manager import AnnDataManager
+from scvi.data.anndata import AnnDataManager
 
 from ._concat_dataloader import ConcatDataLoader
 

--- a/scvi/model/_scvi.py
+++ b/scvi/model/_scvi.py
@@ -5,6 +5,7 @@ from anndata import AnnData
 
 from scvi._compat import Literal
 from scvi._constants import _CONSTANTS
+from scvi.data.anndata import AnnDataManager
 from scvi.data.anndata._utils import _setup_anndata
 from scvi.data.anndata.fields import (
     CategoricalJointObsField,
@@ -12,7 +13,6 @@ from scvi.data.anndata.fields import (
     LayerField,
     NumericalJointObsField,
 )
-from scvi.data.anndata.manager import AnnDataManager
 from scvi.model._utils import _init_library_size
 from scvi.model.base import UnsupervisedTrainingMixin
 from scvi.module import VAE

--- a/scvi/model/_scvi.py
+++ b/scvi/model/_scvi.py
@@ -96,8 +96,10 @@ class SCVI(
         super(SCVI, self).__init__(adata)
 
         n_cats_per_cov = (
-            self.registry["extra_categoricals"]["n_cats_per_key"]
-            if "extra_categoricals" in self.registry
+            self.adata_manager.get_state_registry(_CONSTANTS.CAT_COVS_KEY).get(
+                CategoricalJointObsField.N_CATS_PER_KEY
+            )
+            if _CONSTANTS.CAT_COVS_KEY in self.adata_manager.registry
             else None
         )
         n_batch = self.summary_stats["n_batch"]
@@ -184,6 +186,7 @@ class SCVI(
         categorical_covariate_keys: Optional[List[str]] = None,
         continuous_covariate_keys: Optional[List[str]] = None,
         layer: Optional[str] = None,
+        **kwargs,
     ):
         """
         %(summary)s.
@@ -196,6 +199,7 @@ class SCVI(
         %(param_cat_cov_keys)s
         %(param_cont_cov_keys)s
         """
+        setup_inputs = cls._get_setup_inputs(**locals())
         anndata_fields = [
             LayerField(_CONSTANTS.X_KEY, layer, is_count_data=True),
             CategoricalObsField(_CONSTANTS.BATCH_KEY, batch_key),
@@ -205,6 +209,6 @@ class SCVI(
             ),
             NumericalJointObsField(_CONSTANTS.CONT_COVS_KEY, continuous_covariate_keys),
         ]
-        adata_manager = AnnDataManager(fields=anndata_fields)
-        adata_manager.register_fields(adata)
+        adata_manager = AnnDataManager(fields=anndata_fields, setup_inputs=setup_inputs)
+        adata_manager.register_fields(adata, **kwargs)
         cls._register_manager(adata_manager)

--- a/scvi/model/_scvi.py
+++ b/scvi/model/_scvi.py
@@ -199,7 +199,7 @@ class SCVI(
         %(param_cat_cov_keys)s
         %(param_cont_cov_keys)s
         """
-        setup_inputs = cls._get_setup_inputs(**locals())
+        setup_method_args = cls._get_setup_method_args(**locals())
         anndata_fields = [
             LayerField(_CONSTANTS.X_KEY, layer, is_count_data=True),
             CategoricalObsField(_CONSTANTS.BATCH_KEY, batch_key),
@@ -209,6 +209,8 @@ class SCVI(
             ),
             NumericalJointObsField(_CONSTANTS.CONT_COVS_KEY, continuous_covariate_keys),
         ]
-        adata_manager = AnnDataManager(fields=anndata_fields, setup_inputs=setup_inputs)
+        adata_manager = AnnDataManager(
+            fields=anndata_fields, setup_method_args=setup_method_args
+        )
         adata_manager.register_fields(adata, **kwargs)
         cls.register_manager(adata_manager)

--- a/scvi/model/_scvi.py
+++ b/scvi/model/_scvi.py
@@ -211,4 +211,4 @@ class SCVI(
         ]
         adata_manager = AnnDataManager(fields=anndata_fields, setup_inputs=setup_inputs)
         adata_manager.register_fields(adata, **kwargs)
-        cls._register_manager(adata_manager)
+        cls.register_manager(adata_manager)

--- a/scvi/model/_scvi.py
+++ b/scvi/model/_scvi.py
@@ -193,6 +193,8 @@ class SCVI(
         %(param_batch_key)s
         %(param_labels_key)s
         %(param_layer)s
+        %(param_cat_cov_keys)s
+        %(param_cont_cov_keys)s
         """
         anndata_fields = [
             LayerField(_CONSTANTS.X_KEY, layer, is_count_data=True),

--- a/scvi/model/_utils.py
+++ b/scvi/model/_utils.py
@@ -70,7 +70,7 @@ def scrna_raw_counts_properties(
     Parameters
     ----------
     adata_manager
-        AnnDataManager object setup with `SCVI`.
+        :class:`~scvi.data.anndata.AnnDataManager` object setup with :class:`~scvi.model.SCVI`.
     idx1
         subset of indices describing the first population.
     idx2
@@ -137,7 +137,7 @@ def cite_seq_raw_counts_properties(
     Parameters
     ----------
     adata_manager
-        AnnDataManager object setup with `TOTALVI`.
+        :class:`~scvi.data.anndata.AnnDataManager` object setup with :class:`~scvi.model.TOTALVI`.
     idx1
         subset of indices describing the first population.
     idx2
@@ -182,7 +182,7 @@ def scatac_raw_counts_properties(
     Parameters
     ----------
     adata_manager
-        AnnDataManager object setup with `SCVI`.
+        :class:`~scvi.data.anndata.AnnDataManager` object setup with :class:`~scvi.model.SCVI`.
     idx1
         subset of indices describing the first population.
     idx2
@@ -243,7 +243,7 @@ def _init_library_size(
     Parameters
     ----------
     adata_manager
-        AnnDataManager object setup with `SCVI`.
+        :class:`~scvi.data.anndata.AnnDataManager` object setup with :class:`~scvi.model.SCVI`.
     n_batch
         Number of batches.
 

--- a/scvi/model/_utils.py
+++ b/scvi/model/_utils.py
@@ -8,8 +8,8 @@ import scipy.sparse as sp_sparse
 import torch
 
 from scvi import _CONSTANTS
+from scvi.data.anndata import AnnDataManager
 from scvi.data.anndata.fields import CategoricalObsField
-from scvi.data.anndata.manager import AnnDataManager
 
 logger = logging.getLogger(__name__)
 

--- a/scvi/model/base/_base_model.py
+++ b/scvi/model/base/_base_model.py
@@ -89,7 +89,7 @@ class BaseModelClass(metaclass=BaseModelMetaClass):
         cls, adata: AnnData, required: bool = False
     ) -> Optional[AnnDataManager]:
         """
-        Retrieves the AnnDataManager for a given AnnData object specific to this model class.
+        Retrieves the :class:`~scvi.data.anndata.AnnDataManager` for a given AnnData object specific to this model class.
 
         Parameters
         ----------
@@ -219,7 +219,7 @@ class BaseModelClass(metaclass=BaseModelMetaClass):
                 "Input adata not setup with scvi-tools. "
                 + "attempting to transfer anndata setup"
             )
-            self._register_manager(self.adata_manager.transfer_setup(adata))
+            self.register_manager(self.adata_manager.transfer_setup(adata))
         elif (
             adata_manager.registry[_SOURCE_SCVI_UUID_KEY]
             != self.adata_manager.registry[_SCVI_UUID_KEY]
@@ -228,7 +228,7 @@ class BaseModelClass(metaclass=BaseModelMetaClass):
                 "Input AnnData setup with AnnData the model was initialized with. "
                 "Attempting to transfer setup with initial AnnData."
             )
-            self._register_manager(self.adata_manager.transfer_setup(adata))
+            self.register_manager(self.adata_manager.transfer_setup(adata))
 
         return adata
 
@@ -439,7 +439,7 @@ class BaseModelClass(metaclass=BaseModelMetaClass):
 
         if "scvi_setup_dict_" in attr_dict:
             scvi_setup_dict = attr_dict.pop("scvi_setup_dict_")
-            cls._register_manager(manager_from_setup_dict(cls, adata, scvi_setup_dict))
+            cls.register_manager(manager_from_setup_dict(cls, adata, scvi_setup_dict))
         else:
             registry = attr_dict.pop("registry_")
             if (
@@ -503,9 +503,9 @@ class BaseModelClass(metaclass=BaseModelMetaClass):
         return {_MODEL_NAME_KEY: model_name, _SETUP_KWARGS_KEY: setup_kwargs}
 
     @classmethod
-    def _register_manager(cls, adata_manager: AnnDataManager):
+    def register_manager(cls, adata_manager: AnnDataManager):
         """
-        Registers an AnnDataManager instance with this model class.
+        Registers an :class:`~scvi.data.anndata.AnnDataManager` instance with this model class.
         """
         adata_uuid = adata_manager.get_adata_uuid()
         cls.manager_store[adata_uuid] = adata_manager
@@ -524,7 +524,7 @@ class BaseModelClass(metaclass=BaseModelMetaClass):
 
         Each model class deriving from this class provides parameters to this method
         according to its needs. To operate correctly with the model initialization,
-        the implementation must call `_register_manager` on a model-specific instance
-        of `AnnDataManager`.
+        the implementation must call :meth:`~scvi.model.base.BaseModelClass.register_manager`
+        on a model-specific instance of :class:`~scvi.data.anndata.AnnDataManager`.
         """
         pass

--- a/scvi/model/base/_base_model.py
+++ b/scvi/model/base/_base_model.py
@@ -48,6 +48,7 @@ class BaseModelClass(metaclass=BaseModelMetaClass):
         if adata is not None:
             self.adata_manager = self.get_anndata_manager(adata, required=True)
             self.adata = self.adata_manager.adata
+            # Suffix registry instance variable with _ to include it when saving the model.
             self.registry_ = self.adata_manager.registry
             self.summary_stats = self.adata_manager.summary_stats
 
@@ -493,7 +494,13 @@ class BaseModelClass(metaclass=BaseModelMetaClass):
         return ""
 
     @staticmethod
-    def _get_setup_inputs(**setup_locals) -> dict:
+    def _get_setup_method_args(**setup_locals) -> dict:
+        """
+        Returns a dictionary organizing the arguments used to call ``setup_anndata``.
+
+        Must be called with ``**locals()`` at the start of the ``setup_anndata`` method
+        to avoid the inclusion of any extraneous variables.
+        """
         cls = setup_locals.pop("cls")
         model_name = cls.__name__
         setup_kwargs = dict()

--- a/scvi/model/base/_base_model.py
+++ b/scvi/model/base/_base_model.py
@@ -12,6 +12,7 @@ import torch
 from anndata import AnnData
 
 from scvi import settings
+from scvi.data.anndata import AnnDataManager
 from scvi.data.anndata._compat import manager_from_setup_dict
 from scvi.data.anndata._constants import (
     _MODEL_NAME_KEY,
@@ -19,7 +20,6 @@ from scvi.data.anndata._constants import (
     _SETUP_KWARGS_KEY,
     _SOURCE_SCVI_UUID_KEY,
 )
-from scvi.data.anndata.manager import AnnDataManager
 from scvi.dataloaders import AnnDataLoader
 from scvi.model._utils import parse_use_gpu_arg
 from scvi.module.base import PyroBaseModuleClass


### PR DESCRIPTION
This PR enables save load with the new registry in addition to backwards compatibility in the old setup dict.

This is done by adding a **kwargs argument to setup_anndata for the purpose of transferring setup from a loaded model. Developers will be instructed to follow the boilerplate of the original function to do the same thing (moving it into it's own function is avoided to keep the developer experience consistent).