### PR TITLE
Adapt TotalVI to new setup

### DIFF
--- a/scvi/_constants.py
+++ b/scvi/_constants.py
@@ -5,7 +5,7 @@ class _CONSTANTS_NT(NamedTuple):
     X_KEY: str = "X"
     BATCH_KEY: str = "batch"
     LABELS_KEY: str = "labels"
-    PROTEIN_EXP_KEY: str = "protein_expression"
+    PROTEIN_EXP_KEY: str = "proteins"
     CAT_COVS_KEY: str = "extra_categorical_covs"
     CONT_COVS_KEY: str = "extra_continuous_covs"
 

--- a/scvi/data/anndata/_manager.py
+++ b/scvi/data/anndata/_manager.py
@@ -37,7 +37,7 @@ class AnnDataManager:
         setup_method_args: Optional[dict] = None,
     ) -> None:
         self.adata = None
-        self.fields = set(fields or {})
+        self.fields = fields or []
         self._registry = {
             _constants._SCVI_VERSION_KEY: scvi.__version__,
             _constants._SOURCE_SCVI_UUID_KEY: None,
@@ -87,7 +87,7 @@ class AnnDataManager:
 
     def _freeze_fields(self):
         """Freezes the fields associated with this instance."""
-        self.fields = frozenset(self.fields)
+        self.fields = tuple(self.fields)
 
     def register_fields(
         self, adata: AnnData, source_registry: Optional[dict] = None, **transfer_kwargs

--- a/scvi/data/anndata/fields/__init__.py
+++ b/scvi/data/anndata/fields/__init__.py
@@ -1,7 +1,8 @@
 from ._base_field import BaseAnnDataField
 from ._layer_field import LayerField
 from ._obs_field import CategoricalObsField
-from ._obsm_field import CategoricalJointObsField, NumericalJointObsField
+from ._obsm_field import CategoricalJointObsField, NumericalJointObsField, ObsmField
+from ._totalvi import ProteinObsmField
 
 __all__ = [
     "BaseAnnDataField",
@@ -9,4 +10,6 @@ __all__ = [
     "CategoricalObsField",
     "NumericalJointObsField",
     "CategoricalJointObsField",
+    "ObsmField",
+    "ProteinObsmField",
 ]

--- a/scvi/data/anndata/fields/_base_field.py
+++ b/scvi/data/anndata/fields/_base_field.py
@@ -116,7 +116,7 @@ class BaseAnnDataField(ABC):
         """
         return dict()
 
-    def get_field(self, adata: AnnData) -> Union[np.ndarray, pd.DataFrame]:
+    def get_field_data(self, adata: AnnData) -> Union[np.ndarray, pd.DataFrame]:
         """Returns the requested data as determined by the field for a given AnnData object."""
         assert not self.is_empty
         return get_anndata_attribute(adata, self.attr_name, self.attr_key)

--- a/scvi/data/anndata/fields/_layer_field.py
+++ b/scvi/data/anndata/fields/_layer_field.py
@@ -57,7 +57,7 @@ class LayerField(BaseAnnDataField):
 
     def validate_field(self, adata: AnnData) -> None:
         super().validate_field(adata)
-        x = self.get_field(adata)
+        x = self.get_field_data(adata)
 
         if self.is_count_data and not _check_nonnegative_integers(x):
             logger_data_loc = (

--- a/scvi/data/anndata/fields/_obs_field.py
+++ b/scvi/data/anndata/fields/_obs_field.py
@@ -71,7 +71,7 @@ class CategoricalObsField(BaseObsField):
     def validate_field(self, adata: AnnData) -> None:
         super().validate_field(adata)
         if self._original_attr_key not in adata.obs:
-            raise AssertionError(f"{self._original_attr_key} not found in adata.obs.")
+            raise KeyError(f"{self._original_attr_key} not found in adata.obs.")
 
     def register_field(self, adata: AnnData) -> dict:
         if self.is_default:

--- a/scvi/data/anndata/fields/_obs_field.py
+++ b/scvi/data/anndata/fields/_obs_field.py
@@ -53,8 +53,6 @@ class CategoricalObsField(BaseObsField):
     """
 
     CATEGORICAL_MAPPING_KEY = "categorical_mapping"
-    CM_ORIGINAL_KEY = "original_key"
-    CM_MAPPING_KEY = "mapping"
 
     def __init__(self, registry_key: str, obs_key: Optional[str]) -> None:
         self.is_default = obs_key is None
@@ -64,6 +62,7 @@ class CategoricalObsField(BaseObsField):
         self.count_stat_key = f"n_{self.registry_key}"
 
     def _setup_default_attr(self, adata: AnnData) -> None:
+        self._original_attr_key = self.attr_key
         adata.obs[self.attr_key] = np.zeros(adata.shape[0], dtype=np.int64)
 
     def _get_original_column(self, adata: AnnData) -> np.ndarray:
@@ -71,7 +70,8 @@ class CategoricalObsField(BaseObsField):
 
     def validate_field(self, adata: AnnData) -> None:
         super().validate_field(adata)
-        assert self._original_attr_key in adata.obs
+        if self._original_attr_key not in adata.obs:
+            raise AssertionError(f"{self._original_attr_key} not found in adata.obs.")
 
     def register_field(self, adata: AnnData) -> dict:
         if self.is_default:

--- a/scvi/data/anndata/fields/_obsm_field.py
+++ b/scvi/data/anndata/fields/_obsm_field.py
@@ -1,10 +1,13 @@
 import logging
-from typing import Dict, List, Optional
+import warnings
+from typing import Dict, List, Optional, Union
 
 import numpy as np
+import pandas as pd
 from anndata import AnnData
 from pandas.api.types import CategoricalDtype
 
+from scvi.data._utils import _check_nonnegative_integers
 from scvi.data.anndata import _constants
 
 from ._base_field import BaseAnnDataField
@@ -31,6 +34,104 @@ class BaseObsmField(BaseAnnDataField):
     @property
     def attr_name(self) -> str:
         return self._attr_name
+
+
+class ObsmField(BaseObsmField):
+    """
+    An AnnDataField for an .obsm field in the AnnData data structure.
+
+    In addition to creating a reference to the .obsm field. Stores the column
+    keys for the obsm field in a more accessible .uns attribute.
+
+    Parameters
+    ----------
+    registry_key
+        Key to register field under in data registry.
+    obsm_key
+        Key to access the field in the AnnData .obsm mapping.
+    colnames_uns_key
+        Key to access column names corresponding to each column of the .obsm field in
+        the AnnData .uns mapping.
+    is_count_data
+        If True, checks if the data are counts during validation.
+    """
+
+    COLUMN_NAMES_KEY = "column_names"
+
+    def __init__(
+        self,
+        registry_key: str,
+        obsm_key: str,
+        colnames_uns_key: Optional[str] = None,
+        is_count_data: bool = False,
+    ) -> None:
+        super().__init__(registry_key)
+        self._attr_key = obsm_key
+        self.colnames_uns_key = colnames_uns_key
+        self.is_count_data = is_count_data
+        self.count_stat_key = f"n_{self.registry_key}"
+
+    @property
+    def attr_key(self) -> str:
+        return self._attr_key
+
+    @property
+    def is_empty(self) -> bool:
+        return False
+
+    def validate_field(self, adata: AnnData) -> None:
+        super().validate_field(adata)
+        assert self.attr_key in adata.obsm, f"{self.attr_key} not found in adata.obsm."
+
+        obsm_data = self.get_field(adata)
+
+        if self.is_count_data and not _check_nonnegative_integers(obsm_data):
+            warnings.warn(
+                f"adata.obsm['{self.attr_key}'] does not contain unnormalized count data. "
+                "Are you sure this is what you want?"
+            )
+
+    def _setup_column_names(self, adata: AnnData) -> Union[list, np.ndarray]:
+        obsm_data = self.get_field(adata)
+        if self.colnames_uns_key is None and isinstance(obsm_data, pd.DataFrame):
+            logger.info(
+                f"Using column names from columns of adata.obsm['{self.attr_key}']"
+            )
+            column_names = list(obsm_data.columns)
+        elif self.colnames_uns_key is not None:
+            logger.info(
+                f"Using protein names from adata.uns['{self.colnames_uns_key}']"
+            )
+            column_names = adata.uns[self.colnames_uns_key]
+        else:
+            logger.info("Generating sequential protein names")
+            column_names = np.arange(obsm_data.shape[1])
+        return column_names
+
+    def register_field(self, adata: AnnData) -> dict:
+        super().register_field(adata)
+
+        column_names = self._setup_column_names(adata)
+
+        return {self.COLUMN_NAMES_KEY: column_names}
+
+    def transfer_field(
+        self, state_registry: dict, adata_target: AnnData, **kwargs
+    ) -> dict:
+        super().transfer_field(state_registry, adata_target, **kwargs)
+        self.validate_field(adata_target)
+        source_n_cols = len(state_registry[self.COLUMN_NAMES_KEY])
+        target_n_cols = self.get_field(adata_target).shape[1]
+        assert source_n_cols == target_n_cols, (
+            f"Target adata.obsm['{self.attr_key}'] has {target_n_cols} which does not match "
+            "the source adata.obsm['{self.attr_key}'] column count of {source_n_cols}."
+        )
+
+        return {self.COLUMN_NAMES_KEY: state_registry[self.COLUMN_NAMES_KEY].copy()}
+
+    def get_summary_stats(self, state_registry: dict) -> dict:
+        n_obsm_cols = len(state_registry[self.COLUMN_NAMES_KEY])
+        return {self.count_stat_key: n_obsm_cols}
 
 
 class JointObsField(BaseObsmField):
@@ -111,8 +212,8 @@ class NumericalJointObsField(JointObsField):
         return self.register_field(adata_target)
 
     def get_summary_stats(self, _state_registry: dict) -> dict:
-        n_continuous_covariates = len(self.obs_keys)
-        return {self.count_stat_key: n_continuous_covariates}
+        n_obs_keys = len(self.obs_keys)
+        return {self.count_stat_key: n_obs_keys}
 
 
 class CategoricalJointObsField(JointObsField):
@@ -201,8 +302,8 @@ class CategoricalJointObsField(JointObsField):
         return self._make_obsm_categorical(adata_target, category_dict=source_cat_dict)
 
     def get_summary_stats(self, _state_registry: dict) -> dict:
-        n_categorical_covariates = len(self.obs_keys)
+        n_obs_keys = len(self.obs_keys)
 
         return {
-            self.count_stat_key: n_categorical_covariates,
+            self.count_stat_key: n_obs_keys,
         }

--- a/scvi/data/anndata/fields/_totalvi.py
+++ b/scvi/data/anndata/fields/_totalvi.py
@@ -58,7 +58,7 @@ class ProteinObsmField(ObsmField):
         The mask is over cell measurement columns that are present (observed)
         in each batch. Absence is defined by all 0 for that protein in that batch.
         """
-        pro_exp = self.get_field(adata)
+        pro_exp = self.get_field_data(adata)
         pro_exp = pro_exp.to_numpy() if isinstance(pro_exp, pd.DataFrame) else pro_exp
         batches = adata.obs[self.batch_key].values
         batch_mask = {}

--- a/scvi/data/anndata/fields/_totalvi.py
+++ b/scvi/data/anndata/fields/_totalvi.py
@@ -62,11 +62,11 @@ class ProteinObsmField(ObsmField):
         pro_exp = pro_exp.to_numpy() if isinstance(pro_exp, pd.DataFrame) else pro_exp
         batches = adata.obs[self.batch_key].values
         batch_mask = {}
-        for b_code, b in enumerate(np.unique(batches)):
+        for b in np.unique(batches):
             b_inds = np.where(batches.ravel() == b)[0]
             batch_sum = pro_exp[b_inds, :].sum(axis=0)
             all_zero = batch_sum == 0
-            batch_mask[b_code] = ~all_zero
+            batch_mask[b] = ~all_zero
 
         if np.sum([~b[1] for b in batch_mask.items()]) > 0:
             logger.info("Found batches with missing protein expression")

--- a/scvi/data/anndata/fields/_totalvi.py
+++ b/scvi/data/anndata/fields/_totalvi.py
@@ -1,0 +1,96 @@
+import logging
+from typing import Optional
+
+import numpy as np
+import pandas as pd
+from anndata import AnnData
+
+from ._obsm_field import ObsmField
+
+logger = logging.getLogger(__name__)
+
+
+class ProteinObsmField(ObsmField):
+    """
+    An AnnDataField for an protein data stored in an .obsm field of an AnnData object.
+
+    For usage with the TotalVI model. Computes an additional mask which indicates
+    where batches are missing protein data.
+
+    Parameters
+    ----------
+    registry_key
+        Key to register field under in data registry.
+    obsm_key
+        Key to access the field in the AnnData .obsm mapping.
+    batch_key
+        Key corresponding to the .obs field where batch indices are stored.
+        Used for computing a batch mask over the data for missing protein data.
+    colnames_uns_key
+        Key to access column names corresponding to each column of the .obsm field in
+        the AnnData .uns mapping.
+    is_count_data
+        If True, checks if the data are counts during validation.
+    """
+
+    PROTEIN_BATCH_MASK = "protein_batch_mask"
+
+    def __init__(
+        self,
+        registry_key: str,
+        obsm_key: str,
+        batch_key: str,
+        colnames_uns_key: Optional[str] = None,
+        is_count_data: bool = False,
+    ) -> None:
+        super().__init__(
+            registry_key,
+            obsm_key,
+            colnames_uns_key=colnames_uns_key,
+            is_count_data=is_count_data,
+        )
+        self.batch_key = batch_key
+
+    def _get_batch_mask_protein_data(self, adata: AnnData) -> Optional[dict]:
+        """
+        Returns a dict with length number of batches where each entry is a mask.
+
+        The mask is over cell measurement columns that are present (observed)
+        in each batch. Absence is defined by all 0 for that protein in that batch.
+        """
+        pro_exp = self.get_field(adata)
+        pro_exp = pro_exp.to_numpy() if isinstance(pro_exp, pd.DataFrame) else pro_exp
+        batches = adata.obs[self.batch_key].values
+        batch_mask = {}
+        for b_code, b in enumerate(np.unique(batches)):
+            b_inds = np.where(batches.ravel() == b)[0]
+            batch_sum = pro_exp[b_inds, :].sum(axis=0)
+            all_zero = batch_sum == 0
+            batch_mask[b_code] = ~all_zero
+
+        if np.sum([~b[1] for b in batch_mask.items()]) > 0:
+            logger.info("Found batches with missing protein expression")
+            return batch_mask
+
+        return None
+
+    def register_field(self, adata: AnnData) -> dict:
+        state_registry = super().register_field(adata)
+
+        batch_mask = self._get_batch_mask_protein_data(adata)
+        if batch_mask is not None:
+            state_registry[self.PROTEIN_BATCH_MASK] = batch_mask
+
+        return state_registry
+
+    def transfer_field(
+        self, state_registry: dict, adata_target: AnnData, **kwargs
+    ) -> dict:
+        transfer_state_registry = super().transfer_field(
+            state_registry, adata_target, **kwargs
+        )
+        batch_mask = self._get_batch_mask_protein_data(adata_target)
+        if batch_mask is not None:
+            transfer_state_registry[self.PROTEIN_BATCH_MASK] = batch_mask
+
+        return transfer_state_registry

--- a/scvi/model/_totalvi.py
+++ b/scvi/model/_totalvi.py
@@ -1217,12 +1217,13 @@ class TOTALVI(RNASeqMixin, VAEMixin, ArchesMixin, BaseModelClass):
         %(returns)s
         """
         setup_method_args = cls._get_setup_method_args(**locals())
+        batch_field = CategoricalObsField(_CONSTANTS.BATCH_KEY, batch_key)
         anndata_fields = [
             LayerField(_CONSTANTS.X_KEY, layer, is_count_data=True),
             CategoricalObsField(
                 _CONSTANTS.LABELS_KEY, None
             ),  # Default labels field for compatibility with TOTALVAE
-            CategoricalObsField(_CONSTANTS.BATCH_KEY, batch_key),
+            batch_field,
             CategoricalJointObsField(
                 _CONSTANTS.CAT_COVS_KEY, categorical_covariate_keys
             ),
@@ -1230,7 +1231,7 @@ class TOTALVI(RNASeqMixin, VAEMixin, ArchesMixin, BaseModelClass):
             ProteinObsmField(
                 _CONSTANTS.PROTEIN_EXP_KEY,
                 protein_expression_obsm_key,
-                batch_key,
+                batch_field.attr_key,
                 colnames_uns_key=protein_names_uns_key,
                 is_count_data=True,
             ),

--- a/scvi/model/_totalvi.py
+++ b/scvi/model/_totalvi.py
@@ -13,7 +13,14 @@ from scvi import _CONSTANTS
 from scvi._compat import Literal
 from scvi._utils import _doc_params
 from scvi.data._utils import _check_nonnegative_integers
-from scvi.data.anndata._utils import _setup_anndata
+from scvi.data.anndata import AnnDataManager
+from scvi.data.anndata.fields import (
+    CategoricalJointObsField,
+    CategoricalObsField,
+    LayerField,
+    NumericalJointObsField,
+    ProteinObsmField,
+)
 from scvi.dataloaders import DataSplitter
 from scvi.model._utils import (
     _get_batch_code_from_category,
@@ -108,11 +115,16 @@ class TOTALVI(RNASeqMixin, VAEMixin, ArchesMixin, BaseModelClass):
         **model_kwargs,
     ):
         super(TOTALVI, self).__init__(adata)
+        self.protein_state_registry = self.adata_manager.get_state_registry(
+            _CONSTANTS.PROTEIN_EXP_KEY
+        )
         if (
-            "totalvi_batch_mask" in self.scvi_setup_dict_.keys()
+            ProteinObsmField.PROTEIN_BATCH_MASK in self.protein_state_registry
             and not override_missing_proteins
         ):
-            batch_mask = self.scvi_setup_dict_["totalvi_batch_mask"]
+            batch_mask = self.protein_state_registry[
+                ProteinObsmField.PROTEIN_BATCH_MASK
+            ]
             msg = (
                 "Some proteins have all 0 counts in some batches. "
                 + "These proteins will be treated as missing measurements; however, "
@@ -132,25 +144,29 @@ class TOTALVI(RNASeqMixin, VAEMixin, ArchesMixin, BaseModelClass):
             else (self.summary_stats["n_proteins"] > 10)
         )
         if emp_prior:
-            prior_mean, prior_scale = _get_totalvi_protein_priors(adata, batch_mask)
+            prior_mean, prior_scale = self._get_totalvi_protein_priors(adata)
         else:
             prior_mean, prior_scale = None, None
 
         n_cats_per_cov = (
-            self.scvi_setup_dict_["extra_categoricals"]["n_cats_per_key"]
-            if "extra_categoricals" in self.scvi_setup_dict_
+            self.adata_manager.get_state_registry(_CONSTANTS.CAT_COVS_KEY)[
+                CategoricalJointObsField.N_CATS_PER_KEY
+            ]
+            if _CONSTANTS.CAT_COVS_KEY in self.adata_manager.data_registry
             else None
         )
 
         n_batch = self.summary_stats["n_batch"]
-        library_log_means, library_log_vars = _init_library_size(adata, n_batch)
+        library_log_means, library_log_vars = _init_library_size(
+            self.adata_manager, n_batch
+        )
 
         self.module = TOTALVAE(
             n_input_genes=self.summary_stats["n_vars"],
             n_input_proteins=self.summary_stats["n_proteins"],
             n_batch=n_batch,
             n_latent=n_latent,
-            n_continuous_cov=self.summary_stats["n_continuous_covs"],
+            n_continuous_cov=self.summary_stats["n_extra_continuous_covs"],
             n_cats_per_cov=n_cats_per_cov,
             gene_dispersion=gene_dispersion,
             protein_dispersion=protein_dispersion,
@@ -266,7 +282,7 @@ class TOTALVI(RNASeqMixin, VAEMixin, ArchesMixin, BaseModelClass):
         plan_kwargs = plan_kwargs if isinstance(plan_kwargs, dict) else dict()
 
         data_splitter = DataSplitter(
-            self.adata,
+            self.adata_manager,
             train_size=train_size,
             validation_size=validation_size,
             batch_size=batch_size,
@@ -406,6 +422,7 @@ class TOTALVI(RNASeqMixin, VAEMixin, ArchesMixin, BaseModelClass):
         Otherwise, shape is ``(cells, genes)``. Return type is ``pd.DataFrame`` unless ``return_numpy`` is True.
         """
         adata = self._validate_anndata(adata)
+        adata_manager = self.get_anndata_manager(adata)
         if indices is None:
             indices = np.arange(adata.n_obs)
         if n_samples_overall is not None:
@@ -417,12 +434,14 @@ class TOTALVI(RNASeqMixin, VAEMixin, ArchesMixin, BaseModelClass):
         if gene_list is None:
             gene_mask = slice(None)
         else:
-            all_genes = _get_var_names_from_setup_anndata(adata)
+            all_genes = adata.var_names
             gene_mask = [True if gene in gene_list else False for gene in all_genes]
         if protein_list is None:
             protein_mask = slice(None)
         else:
-            all_proteins = self.scvi_setup_dict_["protein_names"]
+            all_proteins = self.protein_state_registry[
+                ProteinObsmField.COLUMN_NAMES_KEY
+            ]
             protein_mask = [True if p in protein_list else False for p in all_proteins]
         if indices is None:
             indices = np.arange(adata.n_obs)
@@ -437,7 +456,7 @@ class TOTALVI(RNASeqMixin, VAEMixin, ArchesMixin, BaseModelClass):
         if not isinstance(transform_batch, IterableClass):
             transform_batch = [transform_batch]
 
-        transform_batch = _get_batch_code_from_category(adata, transform_batch)
+        transform_batch = _get_batch_code_from_category(adata_manager, transform_batch)
 
         scale_list_gene = []
         scale_list_pro = []
@@ -510,9 +529,12 @@ class TOTALVI(RNASeqMixin, VAEMixin, ArchesMixin, BaseModelClass):
                 columns=adata.var_names[gene_mask],
                 index=adata.obs_names[indices],
             )
+            protein_names = self.protein_state_registry[
+                ProteinObsmField.COLUMN_NAMES_KEY
+            ]
             pro_df = pd.DataFrame(
                 scale_list_pro,
-                columns=self.scvi_setup_dict_["protein_names"][protein_mask],
+                columns=protein_names[protein_mask],
                 index=adata.obs_names[indices],
             )
 
@@ -581,7 +603,9 @@ class TOTALVI(RNASeqMixin, VAEMixin, ArchesMixin, BaseModelClass):
         if protein_list is None:
             protein_mask = slice(None)
         else:
-            all_proteins = self.scvi_setup_dict_["protein_names"]
+            all_proteins = self.protein_state_registry[
+                ProteinObsmField.COLUMN_NAMES_KEY
+            ]
             protein_mask = [True if p in protein_list else False for p in all_proteins]
 
         if n_samples > 1 and return_mean is False:
@@ -597,7 +621,9 @@ class TOTALVI(RNASeqMixin, VAEMixin, ArchesMixin, BaseModelClass):
         if not isinstance(transform_batch, IterableClass):
             transform_batch = [transform_batch]
 
-        transform_batch = _get_batch_code_from_category(adata, transform_batch)
+        transform_batch = _get_batch_code_from_category(
+            self.adata_manager, transform_batch
+        )
         for tensors in post:
             y = tensors[_CONSTANTS.PROTEIN_EXP_KEY]
             py_mixing = torch.zeros_like(y[..., protein_mask])
@@ -633,7 +659,7 @@ class TOTALVI(RNASeqMixin, VAEMixin, ArchesMixin, BaseModelClass):
         if return_numpy is True:
             return 1 - py_mixings
         else:
-            pro_names = self.scvi_setup_dict_["protein_names"]
+            pro_names = self.protein_state_registry[ProteinObsmField.COLUMN_NAMES_KEY]
             foreground_prob = pd.DataFrame(
                 1 - py_mixings,
                 columns=pro_names[protein_mask],
@@ -732,7 +758,7 @@ class TOTALVI(RNASeqMixin, VAEMixin, ArchesMixin, BaseModelClass):
         col_names = np.concatenate(
             [
                 np.asarray(_get_var_names_from_setup_anndata(adata)),
-                self.scvi_setup_dict_["protein_names"],
+                self.protein_state_registry[ProteinObsmField.COLUMN_NAMES_KEY],
             ]
         )
         result = _de_core(
@@ -806,7 +832,9 @@ class TOTALVI(RNASeqMixin, VAEMixin, ArchesMixin, BaseModelClass):
         if protein_list is None:
             protein_mask = slice(None)
         else:
-            all_proteins = self.scvi_setup_dict_["protein_names"]
+            all_proteins = self.protein_state_registry[
+                ProteinObsmField.COLUMN_NAMES_KEY
+            ]
             protein_mask = [True if p in protein_list else False for p in all_proteins]
 
         scdl = self._make_data_loader(
@@ -995,7 +1023,10 @@ class TOTALVI(RNASeqMixin, VAEMixin, ArchesMixin, BaseModelClass):
         corr_matrix = np.mean(np.stack(corr_mats), axis=0)
         var_names = _get_var_names_from_setup_anndata(adata)
         names = np.concatenate(
-            [np.asarray(var_names), self.scvi_setup_dict_["protein_names"]]
+            [
+                np.asarray(var_names),
+                self.protein_state_registry[ProteinObsmField.COLUMN_NAMES_KEY],
+            ]
         )
         return pd.DataFrame(corr_matrix, index=names, columns=names)
 
@@ -1032,7 +1063,7 @@ class TOTALVI(RNASeqMixin, VAEMixin, ArchesMixin, BaseModelClass):
     ):
         adata = super()._validate_anndata(adata=adata, copy_if_view=copy_if_view)
         error_msg = "Number of {} in anndata different from when setup_anndata was run. Please rerun setup_anndata."
-        if _CONSTANTS.PROTEIN_EXP_KEY in adata.uns["_scvi"]["data_registry"].keys():
+        if _CONSTANTS.PROTEIN_EXP_KEY in self.adata_manager.data_registry.keys():
             pro_exp = self.get_from_registry(adata, _CONSTANTS.PROTEIN_EXP_KEY)
             if self.summary_stats["n_proteins"] != pro_exp.shape[1]:
                 raise ValueError(error_msg.format("proteins"))
@@ -1056,8 +1087,14 @@ class TOTALVI(RNASeqMixin, VAEMixin, ArchesMixin, BaseModelClass):
         warnings.filterwarnings("error")
 
         adata = self._validate_anndata(adata)
-        batch = self.get_from_registry(adata, _CONSTANTS.BATCH_KEY).ravel()
-        cats = adata.uns["_scvi"]["categorical_mappings"]["_scvi_batch"]["mapping"]
+        adata_manager = self.get_anndata_manager(adata)
+        batch_mask = adata_manager.get_state_registry(_CONSTANTS.PROTEIN_EXP_KEY).get(
+            ProteinObsmField.PROTEIN_BATCH_MASK
+        )
+        batch = adata_manager.get_from_registry(_CONSTANTS.BATCH_KEY).ravel()
+        cats = adata_manager.get_state_registry(_CONSTANTS.BATCH_KEY)[
+            CategoricalObsField.CATEGORICAL_MAPPING_KEY
+        ]
         codes = np.arange(len(cats))
 
         batch_avg_mus, batch_avg_scales = [], []
@@ -1069,9 +1106,22 @@ class TOTALVI(RNASeqMixin, VAEMixin, ArchesMixin, BaseModelClass):
                 batch_avg_mus.append(0)
                 batch_avg_scales.append(1)
                 continue
-            pro_exp = self.get_from_registry(adata, _CONSTANTS.PROTEIN_EXP_KEY)[
-                batch == b
-            ]
+            pro_exp = adata_manager.get_from_registry(_CONSTANTS.PROTEIN_EXP_KEY)
+            pro_exp = (
+                np.asarray(pro_exp) if isinstance(pro_exp, pd.DataFrame) else pro_exp
+            )
+            pro_exp = pro_exp[batch == b]
+
+            # non missing
+            if batch_mask is not None:
+                pro_exp = pro_exp[:, batch_mask[b]]
+                if pro_exp.shape[1] < 5:
+                    logger.debug(
+                        f"Batch {b} has too few proteins to set prior, setting randomly."
+                    )
+                    batch_avg_mus.append(0.0)
+                    batch_avg_scales.append(0.05)
+                    continue
 
             # for missing batches, put dummy values -- scarches case, will be replaced anyway
             if pro_exp.shape[0] == 0:
@@ -1132,9 +1182,10 @@ class TOTALVI(RNASeqMixin, VAEMixin, ArchesMixin, BaseModelClass):
             background_mean += [b_mean.cpu().numpy()]
         return np.concatenate(background_mean)
 
-    @staticmethod
+    @classmethod
     @setup_anndata_dsp.dedent
     def setup_anndata(
+        cls,
         adata: AnnData,
         protein_expression_obsm_key: str,
         protein_names_uns_key: Optional[str] = None,
@@ -1142,7 +1193,7 @@ class TOTALVI(RNASeqMixin, VAEMixin, ArchesMixin, BaseModelClass):
         layer: Optional[str] = None,
         categorical_covariate_keys: Optional[List[str]] = None,
         continuous_covariate_keys: Optional[List[str]] = None,
-        copy: bool = False,
+        **kwargs,
     ) -> Optional[AnnData]:
         """
         %(summary)s.
@@ -1165,101 +1216,27 @@ class TOTALVI(RNASeqMixin, VAEMixin, ArchesMixin, BaseModelClass):
         -------
         %(returns)s
         """
-        return _setup_anndata(
-            adata,
-            batch_key=batch_key,
-            layer=layer,
-            protein_expression_obsm_key=protein_expression_obsm_key,
-            protein_names_uns_key=protein_names_uns_key,
-            categorical_covariate_keys=categorical_covariate_keys,
-            continuous_covariate_keys=continuous_covariate_keys,
-            copy=copy,
+        setup_method_args = cls._get_setup_method_args(**locals())
+        anndata_fields = [
+            LayerField(_CONSTANTS.X_KEY, layer, is_count_data=True),
+            CategoricalObsField(
+                _CONSTANTS.LABELS_KEY, None
+            ),  # Default labels field for compatibility with TOTALVAE
+            CategoricalObsField(_CONSTANTS.BATCH_KEY, batch_key),
+            CategoricalJointObsField(
+                _CONSTANTS.CAT_COVS_KEY, categorical_covariate_keys
+            ),
+            NumericalJointObsField(_CONSTANTS.CONT_COVS_KEY, continuous_covariate_keys),
+            ProteinObsmField(
+                _CONSTANTS.PROTEIN_EXP_KEY,
+                protein_expression_obsm_key,
+                batch_key,
+                colnames_uns_key=protein_names_uns_key,
+                is_count_data=True,
+            ),
+        ]
+        adata_manager = AnnDataManager(
+            fields=anndata_fields, setup_method_args=setup_method_args
         )
-
-
-def _get_totalvi_protein_priors(adata, batch_mask, n_cells=100):
-    """Compute an empirical prior for protein background."""
-    import warnings
-
-    from sklearn.exceptions import ConvergenceWarning
-    from sklearn.mixture import GaussianMixture
-
-    warnings.filterwarnings("error")
-
-    logger.info("Computing empirical prior initialization for protein background.")
-    batch = get_from_registry(adata, _CONSTANTS.BATCH_KEY).ravel()
-    cats = adata.uns["_scvi"]["categorical_mappings"]["_scvi_batch"]["mapping"]
-    codes = np.arange(len(cats))
-
-    batch_avg_mus, batch_avg_scales = [], []
-    for b in np.unique(codes):
-        # can happen during online updates
-        # the values of these batches will not be used
-        num_in_batch = np.sum(batch == b)
-        if num_in_batch == 0:
-            batch_avg_mus.append(0)
-            batch_avg_scales.append(1)
-            continue
-        pro_exp = get_from_registry(adata, _CONSTANTS.PROTEIN_EXP_KEY)
-        if isinstance(pro_exp, pd.DataFrame):
-            pro_exp = np.asarray(pro_exp)
-        pro_exp = pro_exp[batch == b]
-        # non missing
-        if batch_mask is not None:
-            pro_exp = pro_exp[:, batch_mask[b]]
-            if pro_exp.shape[1] < 5:
-                logger.debug(
-                    f"Batch {b} has too few proteins to set prior, setting randomly."
-                )
-                batch_avg_mus.append(0.0)
-                batch_avg_scales.append(0.05)
-                continue
-
-        # a batch is missing because it's in the reference but not query data
-        # for scarches case, these values will be replaced by original state dict
-        if pro_exp.shape[0] == 0:
-            batch_avg_mus.append(0.0)
-            batch_avg_scales.append(0.05)
-            continue
-
-        cells = np.random.choice(np.arange(pro_exp.shape[0]), size=n_cells)
-        if isinstance(pro_exp, pd.DataFrame):
-            pro_exp = pro_exp.to_numpy()
-        pro_exp = pro_exp[cells]
-        gmm = GaussianMixture(n_components=2)
-        mus, scales = [], []
-        # fit per cell GMM
-        for c in pro_exp:
-            try:
-                gmm.fit(np.log1p(c.reshape(-1, 1)))
-            # when cell is all 0
-            except ConvergenceWarning:
-                mus.append(0)
-                scales.append(0.5)
-                continue
-
-            means = gmm.means_.ravel()
-            sorted_fg_bg = np.argsort(means)
-            mu = means[sorted_fg_bg].ravel()[0]
-            covariances = gmm.covariances_[sorted_fg_bg].ravel()[0]
-            scale = np.sqrt(covariances)
-            mus.append(mu)
-            scales.append(scale)
-
-        # average distribution over cells
-        batch_avg_mu = np.mean(mus)
-        batch_avg_scale = np.sqrt(np.sum(np.square(scales)) / (n_cells ** 2))
-
-        batch_avg_mus.append(batch_avg_mu)
-        batch_avg_scales.append(batch_avg_scale)
-
-    # repeat prior for each protein
-    n_proteins = get_from_registry(adata, _CONSTANTS.PROTEIN_EXP_KEY).shape[1]
-    batch_avg_mus = np.array(batch_avg_mus, dtype=np.float32).reshape(1, -1)
-    batch_avg_scales = np.array(batch_avg_scales, dtype=np.float32).reshape(1, -1)
-    batch_avg_mus = np.tile(batch_avg_mus, (n_proteins, 1))
-    batch_avg_scales = np.tile(batch_avg_scales, (n_proteins, 1))
-
-    warnings.resetwarnings()
-
-    return batch_avg_mus, batch_avg_scales
+        adata_manager.register_fields(adata, **kwargs)
+        cls.register_manager(adata_manager)

--- a/scvi/model/_utils.py
+++ b/scvi/model/_utils.py
@@ -152,7 +152,7 @@ def cite_seq_raw_counts_properties(
     gp = scrna_raw_counts_properties(adata_manager, idx1, idx2)
     protein_exp = adata_manager.get_from_registry(_CONSTANTS.PROTEIN_EXP_KEY)
 
-    nan = np.array([np.nan] * len(adata_manager.summary_stats["protein_names"]))
+    nan = np.array([np.nan] * adata_manager.summary_stats["n_proteins"])
     protein_exp = adata_manager.get_from_registry(_CONSTANTS.PROTEIN_EXP_KEY)
     mean1_pro = np.asarray(protein_exp[idx1].mean(0))
     mean2_pro = np.asarray(protein_exp[idx2].mean(0))

--- a/scvi/model/base/_base_model.py
+++ b/scvi/model/base/_base_model.py
@@ -203,7 +203,7 @@ class BaseModelClass(metaclass=BaseModelMetaClass):
 
     def _validate_anndata(
         self, adata: Optional[AnnData] = None, copy_if_view: bool = True
-    ):
+    ) -> AnnData:
         """Validate anndata has been properly registered, transfer if necessary."""
         if adata is None:
             adata = self.adata
@@ -217,8 +217,8 @@ class BaseModelClass(metaclass=BaseModelMetaClass):
         adata_manager = self.get_anndata_manager(adata)
         if adata_manager is None:
             logger.info(
-                "Input adata not setup with scvi-tools. "
-                + "attempting to transfer anndata setup"
+                "Input AnnData not setup with scvi-tools. "
+                + "attempting to transfer AnnData setup"
             )
             self.register_manager(self.adata_manager.transfer_setup(adata))
         elif (
@@ -226,7 +226,7 @@ class BaseModelClass(metaclass=BaseModelMetaClass):
             != self.adata_manager.registry[_SCVI_UUID_KEY]
         ):
             logger.info(
-                "Input AnnData setup with AnnData the model was initialized with. "
+                "Input AnnData requires setup with AnnData the model was initialized with. "
                 "Attempting to transfer setup with initial AnnData."
             )
             self.register_manager(self.adata_manager.transfer_setup(adata))

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -901,11 +901,11 @@ def test_totalvi(save_path):
     del adata2.obsm["protein_expression"]
     with pytest.raises(AssertionError):
         model.get_elbo(adata2)
-    # model.differential_expression(groupby="labels", group1="label_1")
-    # model.differential_expression(groupby="labels", group1="label_1", group2="label_2")
-    # model.differential_expression(idx1=[0, 1, 2], idx2=[3, 4, 5])
-    # model.differential_expression(idx1=[0, 1, 2])
-    # model.differential_expression(groupby="labels")
+    model.differential_expression(groupby="labels", group1="label_1")
+    model.differential_expression(groupby="labels", group1="label_1", group2="label_2")
+    model.differential_expression(idx1=[0, 1, 2], idx2=[3, 4, 5])
+    model.differential_expression(idx1=[0, 1, 2])
+    model.differential_expression(groupby="labels")
 
     # test with missing proteins
     adata = scvi.data.pbmcs_10x_cite_seq(
@@ -924,7 +924,13 @@ def test_totalvi(save_path):
 
 
 def test_totalvi_model_library_size(save_path):
-    adata = synthetic_iid()
+    adata = synthetic_iid(run_setup_anndata=False)
+    TOTALVI.setup_anndata(
+        adata,
+        batch_key="batch",
+        protein_expression_obsm_key="protein_expression",
+        protein_names_uns_key="protein_names",
+    )
     n_latent = 10
 
     model = TOTALVI(adata, n_latent=n_latent, use_observed_lib_size=False)


### PR DESCRIPTION
Adapts TotalVI to the new setup scheme. Required a lot of changes in places that used hardcoded keys or referenced metadata previously stored on the AnnData.