### PR TITLE
Cleanup Manager register reference with AttrDict implementation

### DIFF
--- a/docs/api/developer.rst
+++ b/docs/api/developer.rst
@@ -202,3 +202,4 @@ Utility functions used by scvi-tools.
 
    utils.track
    utils.setup_anndata_dsp
+   utils.attrdict

--- a/scvi/data/anndata/_manager.py
+++ b/scvi/data/anndata/_manager.py
@@ -7,6 +7,7 @@ import numpy as np
 from anndata import AnnData
 
 import scvi
+from scvi.utils import attrdict
 
 from . import _constants
 from ._utils import (
@@ -64,6 +65,20 @@ class AnnDataManager:
         if adata.is_view:
             raise ValueError("Please run `adata = adata.copy()`")
 
+    def _get_setup_method_args(self) -> dict:
+        """
+        Returns the ``setup_anndata`` method arguments used to initialize this :class:`~scvi.data.anndata.AnnDataManager` instance.
+
+        Returns the ``setup_anndata`` method arguments, including the model name,
+        that were used to initialize this :class:`~scvi.data.anndata.AnnDataManager` instance
+        in the form of a dictionary.
+        """
+        return {
+            k: v
+            for k, v in self._registry.items()
+            if k in {_constants._MODEL_NAME_KEY, _constants._SETUP_KWARGS_KEY}
+        }
+
     def _assign_uuid(self):
         """Assigns a UUID unique to the AnnData object. If already present, the UUID is left alone."""
         self._assert_anndata_registered()
@@ -71,7 +86,7 @@ class AnnDataManager:
         _assign_adata_uuid(self.adata)
 
         scvi_uuid = self.adata.uns[_constants._SCVI_UUID_KEY]
-        self.registry[_constants._SCVI_UUID_KEY] = scvi_uuid
+        self._registry[_constants._SCVI_UUID_KEY] = scvi_uuid
 
     def _assign_source_uuid(self, source_registry: Optional[dict]):
         """
@@ -82,8 +97,8 @@ class AnnDataManager:
         self._assert_anndata_registered()
 
         if source_registry is None:
-            source_registry = self.registry
-        self.registry[_constants._SOURCE_SCVI_UUID_KEY] = self.registry[
+            source_registry = self._registry
+        self._registry[_constants._SOURCE_SCVI_UUID_KEY] = self._registry[
             _constants._SCVI_UUID_KEY
         ]
 
@@ -115,7 +130,7 @@ class AnnDataManager:
 
         self._validate_anndata_object(adata)
         self.adata = adata
-        field_registries = self.registry[_constants._FIELD_REGISTRIES_KEY]
+        field_registries = self._registry[_constants._FIELD_REGISTRIES_KEY]
 
         for field in self.fields:
             field_registries[field.registry_key] = {
@@ -167,63 +182,48 @@ class AnnDataManager:
 
         fields = self.fields
         new_adata_manager = self.__class__(
-            fields=fields, setup_method_args=self.setup_method_args
+            fields=fields, setup_method_args=self._get_setup_method_args()
         )
-        new_adata_manager.register_fields(adata_target, self.registry, **kwargs)
+        new_adata_manager.register_fields(adata_target, self._registry, **kwargs)
         return new_adata_manager
 
     def get_adata_uuid(self) -> str:
         """Returns the UUID for the AnnData object registered with this instance."""
         self._assert_anndata_registered()
 
-        return self.registry[_constants._SCVI_UUID_KEY]
+        return self._registry[_constants._SCVI_UUID_KEY]
 
     @property
-    def registry(self) -> dict:
-        """Returns the top-level registry dictionary for the AnnData object registered with this instance."""
-        return self._registry
+    def registry(self) -> attrdict:
+        """Returns the top-level registry dictionary for the AnnData object registered with this instance as an attrdict."""
+        return attrdict(self._registry)
 
     @property
-    def data_registry(self) -> dict:
+    def data_registry(self) -> attrdict:
         """Returns the data registry for the AnnData object registered with this instance."""
         self._assert_anndata_registered()
 
         data_registry = dict()
-        for registry_key, field_registry in self.registry[
+        for registry_key, field_registry in self._registry[
             _constants._FIELD_REGISTRIES_KEY
         ].items():
             field_data_registry = field_registry[_constants._DATA_REGISTRY_KEY]
             if field_data_registry:
                 data_registry[registry_key] = field_data_registry
 
-        return data_registry
+        return attrdict(data_registry)
 
     @property
-    def summary_stats(self) -> dict:
+    def summary_stats(self) -> attrdict:
         """Returns the summary stats for the AnnData object registered with this instance."""
         self._assert_anndata_registered()
 
         summary_stats = dict()
-        for field_registry in self.registry[_constants._FIELD_REGISTRIES_KEY].values():
+        for field_registry in self._registry[_constants._FIELD_REGISTRIES_KEY].values():
             field_summary_stats = field_registry[_constants._SUMMARY_STATS_KEY]
             summary_stats.update(field_summary_stats)
 
-        return summary_stats
-
-    @property
-    def setup_method_args(self) -> dict:
-        """
-        Returns the ``setup_anndata`` method arguments used to initialize this :class:`~scvi.data.anndata.AnnDataManager` instance.
-
-        Returns the ``setup_anndata`` method arguments, including the model name,
-        that were used to initialize this :class:`~scvi.data.anndata.AnnDataManager` instance
-        in the form of a dictionary.
-        """
-        return {
-            k: v
-            for k, v in self.registry.items()
-            if k in {_constants._MODEL_NAME_KEY, _constants._SETUP_KWARGS_KEY}
-        }
+        return attrdict(summary_stats)
 
     def get_from_registry(self, registry_key: str) -> np.ndarray:
         """
@@ -246,10 +246,12 @@ class AnnDataManager:
 
         return get_anndata_attribute(self.adata, attr_name, attr_key)
 
-    def get_state_registry(self, registry_key: str) -> dict:
+    def get_state_registry(self, registry_key: str) -> attrdict:
         """Returns the state registry for the AnnDataField registered with this instance."""
         self._assert_anndata_registered()
 
-        return self.registry[_constants._FIELD_REGISTRIES_KEY][registry_key][
-            _constants._STATE_REGISTRY_KEY
-        ]
+        return attrdict(
+            self._registry[_constants._FIELD_REGISTRIES_KEY][registry_key][
+                _constants._STATE_REGISTRY_KEY
+            ]
+        )

--- a/scvi/data/anndata/_manager.py
+++ b/scvi/data/anndata/_manager.py
@@ -194,9 +194,9 @@ class AnnDataManager:
         return self._registry[_constants._SCVI_UUID_KEY]
 
     @property
-    def registry(self) -> attrdict:
+    def registry(self) -> dict:
         """Returns the top-level registry dictionary for the AnnData object registered with this instance as an attrdict."""
-        return attrdict(self._registry)
+        return self._registry
 
     @property
     def data_registry(self) -> attrdict:
@@ -211,7 +211,7 @@ class AnnDataManager:
             if field_data_registry:
                 data_registry[registry_key] = field_data_registry
 
-        return attrdict(data_registry)
+        return attrdict(data_registry, recursive=True)
 
     @property
     def summary_stats(self) -> attrdict:

--- a/scvi/data/anndata/fields/_obsm_field.py
+++ b/scvi/data/anndata/fields/_obsm_field.py
@@ -250,7 +250,7 @@ class CategoricalJointObsField(JointObsField):
     """
 
     MAPPINGS_KEY = "mappings"
-    KEYS_KEY = "keys"
+    FIELD_KEYS_KEY = "field_keys"
     N_CATS_PER_KEY = "n_cats_per_key"
 
     def __init__(self, registry_key: str, obs_keys: Optional[List[str]]) -> None:
@@ -258,7 +258,11 @@ class CategoricalJointObsField(JointObsField):
         self.count_stat_key = f"n_{self.registry_key}"
 
     def _default_mappings_dict(self) -> dict:
-        return {self.MAPPINGS_KEY: dict(), self.KEYS_KEY: [], self.N_CATS_PER_KEY: []}
+        return {
+            self.MAPPINGS_KEY: dict(),
+            self.FIELD_KEYS_KEY: [],
+            self.N_CATS_PER_KEY: [],
+        }
 
     def _make_obsm_categorical(
         self, adata: AnnData, category_dict: Optional[Dict[str, List[str]]] = None
@@ -286,7 +290,7 @@ class CategoricalJointObsField(JointObsField):
 
         mappings_dict = self._default_mappings_dict()
         mappings_dict[self.MAPPINGS_KEY] = store_cats
-        mappings_dict[self.KEYS_KEY] = self.obs_keys
+        mappings_dict[self.FIELD_KEYS_KEY] = self.obs_keys
         for k in self.obs_keys:
             mappings_dict[self.N_CATS_PER_KEY].append(len(store_cats[k]))
         return mappings_dict

--- a/scvi/dataloaders/_data_splitting.py
+++ b/scvi/dataloaders/_data_splitting.py
@@ -8,7 +8,6 @@ from torch.utils.data import DataLoader, Dataset
 
 from scvi import REGISTRY_KEYS, settings
 from scvi.data.anndata import AnnDataManager
-from scvi.data.anndata.fields import LabelsWithUnlabeledObsField
 from scvi.dataloaders._ann_dataloader import AnnDataLoader, BatchSampler
 from scvi.dataloaders._semi_dataloader import SemiSupervisedDataLoader
 from scvi.model._utils import parse_use_gpu_arg
@@ -213,9 +212,9 @@ class SemiSupervisedDataSplitter(pl.LightningDataModule):
         self.data_loader_kwargs = kwargs
         self.n_samples_per_label = n_samples_per_label
 
-        original_key = adata_manager.get_state_registry(REGISTRY_KEYS.LABELS_KEY)[
-            LabelsWithUnlabeledObsField.ORIGINAL_ATTR_KEY
-        ]
+        original_key = adata_manager.get_state_registry(
+            REGISTRY_KEYS.LABELS_KEY
+        ).original_key
         labels = np.asarray(adata_manager.adata.obs[original_key]).ravel()
         self._unlabeled_indices = np.argwhere(labels == unlabeled_category).ravel()
         self._labeled_indices = np.argwhere(labels != unlabeled_category).ravel()

--- a/scvi/dataloaders/_semi_dataloader.py
+++ b/scvi/dataloaders/_semi_dataloader.py
@@ -4,7 +4,6 @@ import numpy as np
 
 from scvi import REGISTRY_KEYS
 from scvi.data.anndata import AnnDataManager
-from scvi.data.anndata.fields import LabelsWithUnlabeledObsField
 
 from ._concat_dataloader import ConcatDataLoader
 
@@ -59,9 +58,9 @@ class SemiSupervisedDataLoader(ConcatDataLoader):
 
         self.n_samples_per_label = n_samples_per_label
 
-        labels_obs_key = adata_manager.get_state_registry(REGISTRY_KEYS.LABELS_KEY)[
-            LabelsWithUnlabeledObsField.ORIGINAL_ATTR_KEY
-        ]
+        labels_obs_key = adata_manager.get_state_registry(
+            REGISTRY_KEYS.LABELS_KEY
+        ).original_key
         labels = np.asarray(adata_manager.adata.obs[labels_obs_key]).ravel()
 
         # save a nested list of the indices per labeled category

--- a/scvi/external/cellassign/_model.py
+++ b/scvi/external/cellassign/_model.py
@@ -74,13 +74,13 @@ class CellAssign(UnsupervisedTrainingMixin, BaseModelClass):
             )
         super().__init__(adata)
 
-        self.n_genes = self.summary_stats["n_vars"]
+        self.n_genes = self.summary_stats.n_vars
         self.cell_type_markers = cell_type_markers
         rho = torch.Tensor(cell_type_markers.to_numpy())
         n_cats_per_cov = (
-            self.adata_manager.get_state_registry(REGISTRY_KEYS.CAT_COVS_KEY)[
-                CategoricalJointObsField.N_CATS_PER_KEY
-            ]
+            self.adata_manager.get_state_registry(
+                REGISTRY_KEYS.CAT_COVS_KEY
+            ).n_cats_per_key
             if REGISTRY_KEYS.CAT_COVS_KEY in self.adata_manager.data_registry
             else None
         )
@@ -99,7 +99,7 @@ class CellAssign(UnsupervisedTrainingMixin, BaseModelClass):
             rho=rho,
             basis_means=basis_means,
             b_g_0=col_means_normalized,
-            n_batch=self.summary_stats["n_batch"],
+            n_batch=self.summary_stats.n_batch,
             n_cats_per_cov=n_cats_per_cov,
             n_continuous_cov=self.summary_stats.get("n_extra_continuous_covs", 0),
             **model_kwargs,

--- a/scvi/external/gimvi/_model.py
+++ b/scvi/external/gimvi/_model.py
@@ -92,7 +92,7 @@ class GIMVI(VAEMixin, BaseModelClass):
             "seq": self.get_anndata_manager(adata_seq, required=True),
             "spatial": self.get_anndata_manager(adata_spatial, required=True),
         }
-        self.registries_ = [adm.registry for adm in self.adata_managers.values()]
+        self.registries_ = [adm._registry for adm in self.adata_managers.values()]
 
         seq_var_names = adata_seq.var_names
         spatial_var_names = adata_spatial.var_names

--- a/scvi/external/gimvi/_model.py
+++ b/scvi/external/gimvi/_model.py
@@ -12,11 +12,7 @@ from torch.utils.data import DataLoader
 from scvi import REGISTRY_KEYS
 from scvi.data.anndata import AnnDataManager
 from scvi.data.anndata._compat import manager_from_setup_dict
-from scvi.data.anndata._constants import (
-    _DR_ATTR_KEY,
-    _MODEL_NAME_KEY,
-    _SETUP_KWARGS_KEY,
-)
+from scvi.data.anndata._constants import _MODEL_NAME_KEY, _SETUP_KWARGS_KEY
 from scvi.data.anndata.fields import CategoricalObsField, LayerField
 from scvi.dataloaders import DataSplitter
 from scvi.model._utils import _init_library_size, parse_use_gpu_arg
@@ -92,7 +88,7 @@ class GIMVI(VAEMixin, BaseModelClass):
             "seq": self.get_anndata_manager(adata_seq, required=True),
             "spatial": self.get_anndata_manager(adata_spatial, required=True),
         }
-        self.registries_ = [adm._registry for adm in self.adata_managers.values()]
+        self.registries_ = [adm.registry for adm in self.adata_managers.values()]
 
         seq_var_names = adata_seq.var_names
         spatial_var_names = adata_spatial.var_names
@@ -114,9 +110,9 @@ class GIMVI(VAEMixin, BaseModelClass):
         # of one of the datasets
         adata_seq_n_batches = sum_stats[0]["n_batch"]
         adata_spatial.obs[
-            self.adata_managers["spatial"].data_registry[REGISTRY_KEYS.BATCH_KEY][
-                _DR_ATTR_KEY
-            ]
+            self.adata_managers["spatial"]
+            .data_registry[REGISTRY_KEYS.BATCH_KEY]
+            .attr_key
         ] += adata_seq_n_batches
 
         n_batches = sum(s["n_batch"] for s in sum_stats)

--- a/scvi/external/stereoscope/_model.py
+++ b/scvi/external/stereoscope/_model.py
@@ -44,8 +44,8 @@ class RNAStereoscope(UnsupervisedTrainingMixin, BaseModelClass):
         **model_kwargs,
     ):
         super(RNAStereoscope, self).__init__(sc_adata)
-        self.n_genes = self.summary_stats["n_vars"]
-        self.n_labels = self.summary_stats["n_labels"]
+        self.n_genes = self.summary_stats.n_vars
+        self.n_labels = self.summary_stats.n_labels
         # first we have the scRNA-seq model
         self.module = RNADeconv(
             n_genes=self.n_genes,
@@ -234,9 +234,9 @@ class SpatialStereoscope(UnsupervisedTrainingMixin, BaseModelClass):
         return cls(
             st_adata,
             sc_model.module.get_params(),
-            sc_model.adata_manager.get_state_registry(REGISTRY_KEYS.LABELS_KEY)[
-                CategoricalObsField.CATEGORICAL_MAPPING_KEY
-            ],
+            sc_model.adata_manager.get_state_registry(
+                REGISTRY_KEYS.LABELS_KEY
+            ).categorical_mapping,
             prior_weight=prior_weight,
             **model_kwargs,
         )

--- a/scvi/model/_amortizedlda.py
+++ b/scvi/model/_amortizedlda.py
@@ -59,7 +59,7 @@ class AmortizedLDA(PyroSviTrainMixin, BaseModelClass):
 
         super().__init__(adata)
 
-        n_input = self.summary_stats["n_vars"]
+        n_input = self.summary_stats.n_vars
 
         if (
             cell_topic_prior is not None

--- a/scvi/model/_autozi.py
+++ b/scvi/model/_autozi.py
@@ -110,15 +110,15 @@ class AUTOZI(VAEMixin, UnsupervisedTrainingMixin, BaseModelClass):
         super(AUTOZI, self).__init__(adata)
 
         self.use_observed_lib_size = use_observed_lib_size
-        n_batch = self.summary_stats["n_batch"]
+        n_batch = self.summary_stats.n_batch
         library_log_means, library_log_vars = _init_library_size(
             self.adata_manager, n_batch
         )
 
         self.module = AutoZIVAE(
-            n_input=self.summary_stats["n_vars"],
+            n_input=self.summary_stats.n_vars,
             n_batch=n_batch,
-            n_labels=self.summary_stats["n_labels"],
+            n_labels=self.summary_stats.n_labels,
             n_hidden=n_hidden,
             n_latent=n_latent,
             n_layers=n_layers,

--- a/scvi/model/_condscvi.py
+++ b/scvi/model/_condscvi.py
@@ -63,8 +63,8 @@ class CondSCVI(RNASeqMixin, VAEMixin, UnsupervisedTrainingMixin, BaseModelClass)
     ):
         super(CondSCVI, self).__init__(adata)
 
-        n_labels = self.summary_stats["n_labels"]
-        n_vars = self.summary_stats["n_vars"]
+        n_labels = self.summary_stats.n_labels
+        n_vars = self.summary_stats.n_vars
         if weight_obs:
             ct_counts = np.unique(
                 self.get_from_registry(adata, REGISTRY_KEYS.LABELS_KEY),
@@ -121,16 +121,14 @@ class CondSCVI(RNASeqMixin, VAEMixin, UnsupervisedTrainingMixin, BaseModelClass)
 
         adata = self._validate_anndata(adata)
 
-        mean_vprior = np.zeros(
-            (self.summary_stats["n_labels"], p, self.module.n_latent)
-        )
-        var_vprior = np.zeros((self.summary_stats["n_labels"], p, self.module.n_latent))
+        mean_vprior = np.zeros((self.summary_stats.n_labels, p, self.module.n_latent))
+        var_vprior = np.zeros((self.summary_stats.n_labels, p, self.module.n_latent))
         labels_state_registry = self.adata_manager.get_state_registry(
             REGISTRY_KEYS.LABELS_KEY
         )
-        key = labels_state_registry[CategoricalObsField.ORIGINAL_ATTR_KEY]
-        mapping = labels_state_registry[CategoricalObsField.CATEGORICAL_MAPPING_KEY]
-        for ct in range(self.summary_stats["n_labels"]):
+        key = labels_state_registry.original_key
+        mapping = labels_state_registry.categorical_mapping
+        for ct in range(self.summary_stats.n_labels):
             # pick p cells
             local_indices = np.random.choice(
                 np.where(adata.obs[key] == mapping[ct])[0], p

--- a/scvi/model/_destvi.py
+++ b/scvi/model/_destvi.py
@@ -9,7 +9,7 @@ from anndata import AnnData
 
 from scvi import REGISTRY_KEYS
 from scvi.data.anndata import AnnDataManager
-from scvi.data.anndata.fields import CategoricalObsField, LayerField, NumericalObsField
+from scvi.data.anndata.fields import LayerField, NumericalObsField
 from scvi.model import CondSCVI
 from scvi.model.base import BaseModelClass, UnsupervisedTrainingMixin
 from scvi.module import MRDeconv
@@ -117,9 +117,9 @@ class DestVI(UnsupervisedTrainingMixin, BaseModelClass):
         decoder_state_dict = sc_model.module.decoder.state_dict()
         px_decoder_state_dict = sc_model.module.px_decoder.state_dict()
         px_r = sc_model.module.px_r.detach().cpu().numpy()
-        mapping = sc_model.adata_manager.get_state_registry(REGISTRY_KEYS.LABELS_KEY)[
-            CategoricalObsField.CATEGORICAL_MAPPING_KEY
-        ]
+        mapping = sc_model.adata_manager.get_state_registry(
+            REGISTRY_KEYS.LABELS_KEY
+        ).categorical_mapping
         if vamp_prior_p is None:
             mean_vprior = None
             var_vprior = None

--- a/scvi/model/_linear_scvi.py
+++ b/scvi/model/_linear_scvi.py
@@ -84,13 +84,13 @@ class LinearSCVI(RNASeqMixin, VAEMixin, UnsupervisedTrainingMixin, BaseModelClas
     ):
         super(LinearSCVI, self).__init__(adata)
 
-        n_batch = self.summary_stats["n_batch"]
+        n_batch = self.summary_stats.n_batch
         library_log_means, library_log_vars = _init_library_size(
             self.adata_manager, n_batch
         )
 
         self.module = LDVAE(
-            n_input=self.summary_stats["n_vars"],
+            n_input=self.summary_stats.n_vars,
             n_batch=n_batch,
             n_hidden=n_hidden,
             n_latent=n_latent,

--- a/scvi/model/_multivi.py
+++ b/scvi/model/_multivi.py
@@ -127,9 +127,9 @@ class MULTIVI(VAEMixin, UnsupervisedTrainingMixin, BaseModelClass):
         super().__init__(adata)
 
         n_cats_per_cov = (
-            self.adata_manager.get_state_registry(REGISTRY_KEYS.CAT_COVS_KEY)[
-                CategoricalJointObsField.N_CATS_PER_KEY
-            ]
+            self.adata_manager.get_state_registry(
+                REGISTRY_KEYS.CAT_COVS_KEY
+            ).n_cats_per_key
             if REGISTRY_KEYS.CAT_COVS_KEY in self.adata_manager.data_registry
             else []
         )
@@ -137,7 +137,7 @@ class MULTIVI(VAEMixin, UnsupervisedTrainingMixin, BaseModelClass):
         self.module = MULTIVAE(
             n_input_genes=n_genes,
             n_input_regions=n_regions,
-            n_batch=self.summary_stats["n_batch"],
+            n_batch=self.summary_stats.n_batch,
             n_hidden=n_hidden,
             n_latent=n_latent,
             n_layers_encoder=n_layers_encoder,

--- a/scvi/model/_peakvi.py
+++ b/scvi/model/_peakvi.py
@@ -102,16 +102,16 @@ class PEAKVI(ArchesMixin, VAEMixin, UnsupervisedTrainingMixin, BaseModelClass):
         super(PEAKVI, self).__init__(adata)
 
         n_cats_per_cov = (
-            self.adata_manager.get_state_registry(REGISTRY_KEYS.CAT_COVS_KEY)[
-                CategoricalJointObsField.N_CATS_PER_KEY
-            ]
+            self.adata_manager.get_state_registry(
+                REGISTRY_KEYS.CAT_COVS_KEY
+            ).n_cats_per_key
             if REGISTRY_KEYS.CAT_COVS_KEY in self.adata_manager.data_registry
             else []
         )
 
         self.module = PEAKVAE(
-            n_input_regions=self.summary_stats["n_vars"],
-            n_batch=self.summary_stats["n_batch"],
+            n_input_regions=self.summary_stats.n_vars,
+            n_batch=self.summary_stats.n_batch,
             n_hidden=n_hidden,
             n_latent=n_latent,
             n_layers_encoder=n_layers_encoder,

--- a/scvi/model/_scvi.py
+++ b/scvi/model/_scvi.py
@@ -95,21 +95,21 @@ class SCVI(
         super(SCVI, self).__init__(adata)
 
         n_cats_per_cov = (
-            self.adata_manager.get_state_registry(REGISTRY_KEYS.CAT_COVS_KEY).get(
-                CategoricalJointObsField.N_CATS_PER_KEY
-            )
+            self.adata_manager.get_state_registry(
+                REGISTRY_KEYS.CAT_COVS_KEY
+            ).n_cats_per_key
             if REGISTRY_KEYS.CAT_COVS_KEY in self.adata_manager.registry
             else None
         )
-        n_batch = self.summary_stats["n_batch"]
+        n_batch = self.summary_stats.n_batch
         library_log_means, library_log_vars = _init_library_size(
             self.adata_manager, n_batch
         )
 
         self.module = VAE(
-            n_input=self.summary_stats["n_vars"],
+            n_input=self.summary_stats.n_vars,
             n_batch=n_batch,
-            n_labels=self.summary_stats["n_labels"],
+            n_labels=self.summary_stats.n_labels,
             n_continuous_cov=self.summary_stats.get("n_extra_continuous_covs", 0),
             n_cats_per_cov=n_cats_per_cov,
             n_hidden=n_hidden,

--- a/scvi/model/_utils.py
+++ b/scvi/model/_utils.py
@@ -9,7 +9,6 @@ import torch
 
 from scvi import REGISTRY_KEYS
 from scvi.data.anndata import AnnDataManager
-from scvi.data.anndata.fields import CategoricalObsField
 
 logger = logging.getLogger(__name__)
 
@@ -152,7 +151,7 @@ def cite_seq_raw_counts_properties(
     gp = scrna_raw_counts_properties(adata_manager, idx1, idx2)
     protein_exp = adata_manager.get_from_registry(REGISTRY_KEYS.PROTEIN_EXP_KEY)
 
-    nan = np.array([np.nan] * adata_manager.summary_stats["n_proteins"])
+    nan = np.array([np.nan] * adata_manager.summary_stats.n_proteins)
     protein_exp = adata_manager.get_from_registry(REGISTRY_KEYS.PROTEIN_EXP_KEY)
     mean1_pro = np.asarray(protein_exp[idx1].mean(0))
     mean2_pro = np.asarray(protein_exp[idx2].mean(0))
@@ -213,9 +212,9 @@ def _get_batch_code_from_category(
     if not isinstance(category, IterableClass) or isinstance(category, str):
         category = [category]
 
-    batch_mappings = adata_manager.get_state_registry(REGISTRY_KEYS.BATCH_KEY)[
-        CategoricalObsField.CATEGORICAL_MAPPING_KEY
-    ]
+    batch_mappings = adata_manager.get_state_registry(
+        REGISTRY_KEYS.BATCH_KEY
+    ).categorical_mapping
     batch_code = []
     for cat in category:
         if cat is None:

--- a/scvi/model/base/_base_model.py
+++ b/scvi/model/base/_base_model.py
@@ -50,7 +50,7 @@ class BaseModelClass(metaclass=BaseModelMetaClass):
             self.adata_manager = self.get_anndata_manager(adata, required=True)
             self.adata = self.adata_manager.adata
             # Suffix registry instance variable with _ to include it when saving the model.
-            self.registry_ = self.adata_manager._registry
+            self.registry_ = self.adata_manager.registry
             self.summary_stats = self.adata_manager.summary_stats
 
         self.is_trained_ = False

--- a/scvi/model/base/_base_model.py
+++ b/scvi/model/base/_base_model.py
@@ -50,7 +50,7 @@ class BaseModelClass(metaclass=BaseModelMetaClass):
             self.adata_manager = self.get_anndata_manager(adata, required=True)
             self.adata = self.adata_manager.adata
             # Suffix registry instance variable with _ to include it when saving the model.
-            self.registry_ = self.adata_manager.registry
+            self.registry_ = self.adata_manager._registry
             self.summary_stats = self.adata_manager.summary_stats
 
         self.is_trained_ = False

--- a/scvi/model/base/_differential.py
+++ b/scvi/model/base/_differential.py
@@ -11,7 +11,6 @@ from sklearn.mixture import GaussianMixture
 
 from scvi import REGISTRY_KEYS
 from scvi._compat import Literal
-from scvi.data.anndata.fields import CategoricalObsField
 
 logger = logging.getLogger(__name__)
 
@@ -396,7 +395,7 @@ class DifferentialComputation:
             batch_registry = self.adata_manager.get_state_registry(
                 REGISTRY_KEYS.BATCH_KEY
             )
-            batchid = batch_registry[CategoricalObsField.CATEGORICAL_MAPPING_KEY]
+            batchid = batch_registry.categorical_mapping
         if use_observed_batches:
             if batchid is not None:
                 raise ValueError("Unconsistent batch policy")

--- a/scvi/utils/__init__.py
+++ b/scvi/utils/__init__.py
@@ -1,4 +1,5 @@
+from ._attrdict import attrdict
 from ._docstrings import setup_anndata_dsp
 from ._track import track
 
-__all__ = ["track", "setup_anndata_dsp"]
+__all__ = ["track", "setup_anndata_dsp", "attrdict"]

--- a/scvi/utils/_attrdict.py
+++ b/scvi/utils/_attrdict.py
@@ -5,6 +5,15 @@ class attrdict(dict):
     """
     A dictionary that allows for attribute notation (e.g. d.element).
 
+
+    Parameters
+    ----------
+    recursive
+        If True, recursively converts nested dictionaries into :class:`~scvi.utils.attrdict` objects.
+
+
+    Notes
+    -----
     Based off of https://stackoverflow.com/questions/38034377/object-like-attribute-access-for-nested-dictionary.
     """
 
@@ -28,3 +37,6 @@ class attrdict(dict):
                 self[key] = deepcopy(self[key])
 
         self.__dict__ = self
+
+    def __repr__(self) -> str:
+        return f"attrdict({super().__repr__()})"

--- a/scvi/utils/_attrdict.py
+++ b/scvi/utils/_attrdict.py
@@ -5,12 +5,10 @@ class attrdict(dict):
     """
     A dictionary that allows for attribute notation (e.g. d.element).
 
-
     Parameters
     ----------
     recursive
         If True, recursively converts nested dictionaries into :class:`~scvi.utils.attrdict` objects.
-
 
     Notes
     -----

--- a/scvi/utils/_attrdict.py
+++ b/scvi/utils/_attrdict.py
@@ -1,0 +1,24 @@
+class attrdict(dict):
+    """
+    A dictionary that allows for attribute notation (e.g. d.element).
+
+    Based off of https://stackoverflow.com/questions/38034377/object-like-attribute-access-for-nested-dictionary.
+    """
+
+    def __init__(self, *args, **kwargs):
+        def from_nested_dict(data):
+            if not isinstance(data, dict):
+                return data
+            else:
+                return attrdict({key: from_nested_dict(data[key]) for key in data})
+
+        super().__init__(*args, **kwargs)
+
+        for key in self.keys():
+            if hasattr(self, key):
+                raise ValueError(
+                    f"Cannot create attrdict containing key {key} due to conflict with built-in dict attribute."
+                )
+            self[key] = from_nested_dict(self[key])
+
+        self.__dict__ = self

--- a/scvi/utils/_attrdict.py
+++ b/scvi/utils/_attrdict.py
@@ -1,3 +1,6 @@
+from copy import deepcopy
+
+
 class attrdict(dict):
     """
     A dictionary that allows for attribute notation (e.g. d.element).
@@ -5,7 +8,7 @@ class attrdict(dict):
     Based off of https://stackoverflow.com/questions/38034377/object-like-attribute-access-for-nested-dictionary.
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, recursive: bool = False, **kwargs):
         def from_nested_dict(data):
             if not isinstance(data, dict):
                 return data
@@ -19,6 +22,9 @@ class attrdict(dict):
                 raise ValueError(
                     f"Cannot create attrdict containing key {key} due to conflict with built-in dict attribute."
                 )
-            self[key] = from_nested_dict(self[key])
+            if recursive:
+                self[key] = from_nested_dict(self[key])
+            else:
+                self[key] = deepcopy(self[key])
 
         self.__dict__ = self

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -951,6 +951,7 @@ def test_totalvi(save_path):
     TOTALVI.setup_anndata(
         adata, batch_key="batch", protein_expression_obsm_key="protein_expression"
     )
+    print(TOTALVI.get_anndata_manager(adata)._registry)
     model = TOTALVI(adata)
     assert model.module.protein_batch_mask is not None
     model.train(1, train_size=0.5)

--- a/tests/utils/test_attrdict.py
+++ b/tests/utils/test_attrdict.py
@@ -1,0 +1,29 @@
+import pytest
+
+from scvi.utils import attrdict
+
+
+def test_attrdict_new():
+    ad = attrdict()
+    ad.a = 1
+    assert ad.a == 1 and ad["a"] == 1
+
+    ad["b"] = "test"
+    assert ad.b == "test" and ad["b"] == "test"
+
+    ad.c = {"d": 2}
+    assert isinstance(ad.c, dict) and ad.c["d"] == 2
+    with pytest.raises(AttributeError):
+        print(ad.c.d)
+
+
+def test_attrdict_from_dict():
+    dct = {"a": 1, "b": 2, "c": {"d": 3}}
+    ad = attrdict(dct)
+    assert isinstance(ad, attrdict) and isinstance(ad.c, attrdict)
+    assert ad.a == 1 and ad.b == 2 and ad.c.d == 3
+    assert dict(ad) == dct
+
+    # attrdict creates a copy of dct.
+    ad.a = 2
+    assert ad.a == 2 and dct["a"] == 1

--- a/tests/utils/test_attrdict.py
+++ b/tests/utils/test_attrdict.py
@@ -20,6 +20,20 @@ def test_attrdict_new():
 def test_attrdict_from_dict():
     dct = {"a": 1, "b": 2, "c": {"d": 3}}
     ad = attrdict(dct)
+    assert isinstance(ad, attrdict) and not isinstance(ad.c, attrdict)
+    assert ad.a == 1 and ad.b == 2 and ad.c["d"] == 3
+    assert dict(ad) == dct
+
+    # attrdict creates a copy of dct.
+    ad.a = 2
+    assert ad.a == 2 and dct["a"] == 1
+    ad.c["d"] = 4
+    assert ad.c["d"] == 4 and dct["c"]["d"] == 3
+
+
+def test_attrdict_recursive():
+    dct = {"a": 1, "b": 2, "c": {"d": 3}}
+    ad = attrdict(dct, recursive=True)
     assert isinstance(ad, attrdict) and isinstance(ad.c, attrdict)
     assert ad.a == 1 and ad.b == 2 and ad.c.d == 3
     assert dict(ad) == dct
@@ -27,3 +41,5 @@ def test_attrdict_from_dict():
     # attrdict creates a copy of dct.
     ad.a = 2
     assert ad.a == 2 and dct["a"] == 1
+    ad.c.d = 4
+    assert ad.c.d == 4 and dct["c"]["d"] == 3


### PR DESCRIPTION
Makes data_registry, state_registry, and summary_stats properties return attrdicts which allow users to reference dictionary keys using attribute notation. This cleans up verbose references to field constants without importing the original field class.