### PR TITLE
Always add unlabeled category for scanvi

### DIFF
--- a/scvi/data/anndata/_utils.py
+++ b/scvi/data/anndata/_utils.py
@@ -121,7 +121,6 @@ def _make_obs_column_categorical(
     column_key,
     alternate_column_key,
     categorical_dtype=None,
-    return_mapping=False,
 ):
     """
     Makes the data in column_key in obs all categorical.
@@ -146,16 +145,6 @@ def _make_obs_column_categorical(
         )
     adata.obs[alternate_column_key] = codes
 
-    if not return_mapping:
-        # store categorical mappings
-        store_dict = {
-            alternate_column_key: {"original_key": column_key, "mapping": mapping}
-        }
-
-        if "categorical_mappings" not in adata.uns["_scvi"].keys():
-            adata.uns["_scvi"]["categorical_mappings"] = dict()
-        adata.uns["_scvi"]["categorical_mappings"].update(store_dict)
-
     # make sure each category contains enough cells
     unique, counts = np.unique(adata.obs[alternate_column_key], return_counts=True)
     if np.min(counts) < 3:
@@ -171,7 +160,7 @@ def _make_obs_column_categorical(
             "Is adata.obs['{}'] continuous? SCVI doesn't support continuous obs yet."
         )
 
-    return mapping if return_mapping else alternate_column_key
+    return mapping
 
 
 def _assign_adata_uuid(adata: anndata.AnnData, overwrite: bool = False) -> None:

--- a/scvi/data/anndata/fields/_obs_field.py
+++ b/scvi/data/anndata/fields/_obs_field.py
@@ -135,7 +135,9 @@ class CategoricalObsField(BaseObsField):
 
         super().register_field(adata)
         categorical_mapping = _make_obs_column_categorical(
-            adata, self._original_attr_key, self.attr_key, return_mapping=True
+            adata,
+            self._original_attr_key,
+            self.attr_key,
         )
         return {
             self.CATEGORICAL_MAPPING_KEY: categorical_mapping,
@@ -174,7 +176,6 @@ class CategoricalObsField(BaseObsField):
             self._original_attr_key,
             self.attr_key,
             categorical_dtype=cat_dtype,
-            return_mapping=True,
         )
         return {
             self.CATEGORICAL_MAPPING_KEY: new_mapping,

--- a/scvi/data/anndata/fields/_scanvi.py
+++ b/scvi/data/anndata/fields/_scanvi.py
@@ -55,7 +55,6 @@ class LabelsWithUnlabeledObsField(CategoricalObsField):
                 self._original_attr_key,
                 self.attr_key,
                 categorical_dtype=cat_dtype,
-                return_mapping=True,
             )
             remapped = True
         else:

--- a/scvi/data/anndata/fields/_scanvi.py
+++ b/scvi/data/anndata/fields/_scanvi.py
@@ -50,7 +50,6 @@ class LabelsWithUnlabeledObsField(CategoricalObsField):
             mapping[unlabeled_idx], mapping[-1] = mapping[-1], mapping[unlabeled_idx]
         # could be in mapping in transfer case
         elif self._unlabeled_category not in mapping:
-            # no unlabeled category, so no need to remap
             # just put as last category
             mapping = np.asarray(list(mapping) + [self._unlabeled_category])
 

--- a/scvi/data/anndata/fields/_scanvi.py
+++ b/scvi/data/anndata/fields/_scanvi.py
@@ -48,23 +48,24 @@ class LabelsWithUnlabeledObsField(CategoricalObsField):
             unlabeled_idx = unlabeled_idx[0][0]
             # move unlabeled category to be the last position
             mapping[unlabeled_idx], mapping[-1] = mapping[-1], mapping[unlabeled_idx]
-            cat_dtype = CategoricalDtype(categories=mapping, ordered=True)
-            # rerun setup for the batch column
-            mapping = _make_obs_column_categorical(
-                adata,
-                self._original_attr_key,
-                self.attr_key,
-                categorical_dtype=cat_dtype,
-            )
-            remapped = True
         else:
-            remapped = False
+            # no unlabeled category, so no need to remap
+            # just put as last category
+            mapping = np.asarray(list(mapping) + [self._unlabeled_category])
+
+        cat_dtype = CategoricalDtype(categories=mapping, ordered=True)
+        # rerun setup for the batch column
+        mapping = _make_obs_column_categorical(
+            adata,
+            self._original_attr_key,
+            self.attr_key,
+            categorical_dtype=cat_dtype,
+        )
 
         return {
             self.CATEGORICAL_MAPPING_KEY: mapping,
             self.ORIGINAL_ATTR_KEY: self._original_attr_key,
             self.UNLABELED_CATEGORY: self._unlabeled_category,
-            self.WAS_REMAPPED: remapped,
         }
 
     def register_field(self, adata: AnnData) -> dict:

--- a/scvi/data/anndata/fields/_scanvi.py
+++ b/scvi/data/anndata/fields/_scanvi.py
@@ -48,7 +48,8 @@ class LabelsWithUnlabeledObsField(CategoricalObsField):
             unlabeled_idx = unlabeled_idx[0][0]
             # move unlabeled category to be the last position
             mapping[unlabeled_idx], mapping[-1] = mapping[-1], mapping[unlabeled_idx]
-        else:
+        # could be in mapping in transfer case
+        elif self._unlabeled_category not in mapping:
             # no unlabeled category, so no need to remap
             # just put as last category
             mapping = np.asarray(list(mapping) + [self._unlabeled_category])

--- a/scvi/model/_scanvi.py
+++ b/scvi/model/_scanvi.py
@@ -110,11 +110,7 @@ class SCANVI(RNASeqMixin, VAEMixin, ArchesMixin, BaseModelClass):
             self._dl_cls = AnnDataLoader
 
         # ignores unlabeled catgegory
-        n_labels = (
-            self.summary_stats.n_labels - 1
-            if self.has_unlabeled
-            else self.summary_stats.n_labels
-        )
+        n_labels = self.summary_stats.n_labels - 1
         n_cats_per_cov = (
             self.adata_manager.get_state_registry(
                 REGISTRY_KEYS.CAT_COVS_KEY
@@ -228,7 +224,6 @@ class SCANVI(RNASeqMixin, VAEMixin, ArchesMixin, BaseModelClass):
             REGISTRY_KEYS.LABELS_KEY
         )
         self.unlabeled_category_ = labels_state_registry.unlabeled_category
-        self.has_unlabeled = labels_state_registry.was_remapped
 
         labels = self.get_from_registry(self.adata, REGISTRY_KEYS.LABELS_KEY)
         self._label_mapping = labels_state_registry.categorical_mapping

--- a/tests/models/test_scarches.py
+++ b/tests/models/test_scarches.py
@@ -176,9 +176,19 @@ def test_scanvi_online_update(save_path):
     dir_path = os.path.join(save_path, "saved_model/")
     model.save(dir_path, overwrite=True)
 
+    # query has all missing labels
     adata2 = synthetic_iid()
     adata2.obs["batch"] = adata2.obs.batch.cat.rename_categories(["batch_2", "batch_3"])
     adata2.obs["labels"] = "Unknown"
+
+    model = SCANVI.load_query_data(adata2, dir_path, freeze_batchnorm_encoder=True)
+    model.train(max_epochs=1)
+    model.get_latent_representation()
+    model.predict()
+
+    # query has no missing labels
+    adata2 = synthetic_iid()
+    adata2.obs["batch"] = adata2.obs.batch.cat.rename_categories(["batch_2", "batch_3"])
 
     model = SCANVI.load_query_data(adata2, dir_path, freeze_batchnorm_encoder=True)
     model.train(max_epochs=1)


### PR DESCRIPTION
Even when the labels don't contain the unlabeled category. This fixes an edge case with scarches (see added test case).

I also cleared some unused code.