### PR TITLE
Adata and manager as properties

### DIFF
--- a/scvi/model/base/_base_model.py
+++ b/scvi/model/base/_base_model.py
@@ -96,7 +96,7 @@ class BaseModelClass(metaclass=BaseModelMetaClass):
 
     @property
     def adata_manager(self) -> AnnDataManager:
-        """AnnDataManager instance associated with self.adata."""
+        """Manager instance associated with self.adata."""
         return self._adata_manager
 
     def to_device(self, device: Union[str, int]):

--- a/scvi/model/base/_base_model.py
+++ b/scvi/model/base/_base_model.py
@@ -64,8 +64,8 @@ class BaseModelClass(metaclass=BaseModelMetaClass):
     def __init__(self, adata: Optional[AnnData] = None):
         self.id = str(uuid4())  # Used for cls._manager_store keys.
         if adata is not None:
-            self.adata = adata
-            self.adata_manager = self._get_most_recent_anndata_manager(
+            self._adata = adata
+            self._adata_manager = self._get_most_recent_anndata_manager(
                 adata, required=True
             )
             self._register_manager_for_instance(self.adata_manager)
@@ -80,6 +80,24 @@ class BaseModelClass(metaclass=BaseModelMetaClass):
         self.validation_indices_ = None
         self.history_ = None
         self._data_loader_cls = AnnDataLoader
+
+    @property
+    def adata(self) -> AnnData:
+        """Data attached to model instance."""
+        return self._adata
+
+    @adata.setter
+    def adata(self, adata: AnnData):
+        if adata is None:
+            raise ValueError("adata cannot be None.")
+        self._validate_anndata(adata)
+        self._adata = adata
+        self._adata_manager = self.get_anndata_manager(adata)
+
+    @property
+    def adata_manager(self) -> AnnDataManager:
+        """AnnDataManager instance associated with self.adata."""
+        return self._adata_manager
 
     def to_device(self, device: Union[str, int]):
         """

--- a/scvi/model/base/_base_model.py
+++ b/scvi/model/base/_base_model.py
@@ -70,8 +70,8 @@ class BaseModelClass(metaclass=BaseModelMetaClass):
             )
             self._register_manager_for_instance(self.adata_manager)
             # Suffix registry instance variable with _ to include it when saving the model.
-            self.registry_ = self.adata_manager.registry
-            self.summary_stats = self.adata_manager.summary_stats
+            self.registry_ = self._adata_manager.registry
+            self.summary_stats = self._adata_manager.summary_stats
 
         self.is_trained_ = False
         self._model_summary_string = ""
@@ -93,6 +93,8 @@ class BaseModelClass(metaclass=BaseModelMetaClass):
         self._validate_anndata(adata)
         self._adata = adata
         self._adata_manager = self.get_anndata_manager(adata)
+        self.registry_ = self._adata_manager.registry
+        self.summary_stats = self._adata_manager.summary_stats
 
     @property
     def adata_manager(self) -> AnnDataManager:

--- a/scvi/model/base/_base_model.py
+++ b/scvi/model/base/_base_model.py
@@ -92,7 +92,7 @@ class BaseModelClass(metaclass=BaseModelMetaClass):
             raise ValueError("adata cannot be None.")
         self._validate_anndata(adata)
         self._adata = adata
-        self._adata_manager = self.get_anndata_manager(adata)
+        self._adata_manager = self.get_anndata_manager(adata, required=True)
         self.registry_ = self._adata_manager.registry
         self.summary_stats = self._adata_manager.summary_stats
 

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -280,6 +280,25 @@ def test_scvi_sparse(save_path):
     model.differential_expression(groupby="labels", group1="label_1")
 
 
+def test_setting_adata_attr():
+    n_latent = 5
+    adata = synthetic_iid()
+    SCVI.setup_anndata(adata, batch_key="batch")
+    model = SCVI(adata, n_latent=n_latent)
+    model.train(1, train_size=0.5)
+
+    adata2 = synthetic_iid()
+    model.adata = adata2
+    model.get_latent_representation()
+
+    adata3 = synthetic_iid()
+    del adata3.obs["batch"]
+    # validation catches no batch
+    with pytest.raises(KeyError):
+        model.adata = adata3
+        model.get_latent_representation()
+
+
 def test_saving_and_loading(save_path):
     def legacy_save(
         model,

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -289,7 +289,15 @@ def test_setting_adata_attr():
 
     adata2 = synthetic_iid()
     model.adata = adata2
-    model.get_latent_representation()
+
+    with pytest.raises(AssertionError):
+        rep = model.get_latent_representation(adata)
+        rep2 = model.get_latent_representation()
+        np.testing.assert_array_equal(rep, rep2)
+
+    orig_manager = model.get_anndata_manager(adata)
+    assert model.registry_ is not orig_manager.registry
+    assert model.summary_stats is not orig_manager.summary_stats
 
     adata3 = synthetic_iid()
     del adata3.obs["batch"]


### PR DESCRIPTION
Prevents arbitrary setting of sensitive model attributes.

Should we make registry_ and summary_stats as properties that pull from the current adata_manager? I don't think it matters?