### PR TITLE
Fix `SOLO.from_scvi_model` when original model uses `labels_key`

### DIFF
--- a/tests/external/test_solo.py
+++ b/tests/external/test_solo.py
@@ -3,7 +3,7 @@ from scvi.external import SOLO
 from scvi.model import SCVI
 
 
-def test_solo(save_path):
+def test_solo():
     n_latent = 5
     adata = synthetic_iid()
     SCVI.setup_anndata(adata)
@@ -22,7 +22,7 @@ def test_solo(save_path):
     solo.predict()
 
 
-def test_solo_multiple_batch(save_path):
+def test_solo_multiple_batch():
     n_latent = 5
     adata = synthetic_iid()
     adata.layers["my_layer"] = adata.X.copy()
@@ -31,6 +31,19 @@ def test_solo_multiple_batch(save_path):
     model.train(1, check_val_every_n_epoch=1, train_size=0.5)
 
     solo = SOLO.from_scvi_model(model, restrict_to_batch="batch_0")
+    solo.train(1, check_val_every_n_epoch=1, train_size=0.9)
+    assert "validation_loss" in solo.history.keys()
+    solo.predict()
+
+
+def test_solo_scvi_labels():
+    n_latent = 5
+    adata = synthetic_iid()
+    SCVI.setup_anndata(adata, labels_key="labels")
+    model = SCVI(adata, n_latent=n_latent)
+    model.train(1, check_val_every_n_epoch=1, train_size=0.5)
+
+    solo = SOLO.from_scvi_model(model)
     solo.train(1, check_val_every_n_epoch=1, train_size=0.9)
     assert "validation_loss" in solo.history.keys()
     solo.predict()


### PR DESCRIPTION
Fixes #1163