### PR TITLE
`view_setup_args` for saved model paths

### DIFF
--- a/scvi/data/anndata/_compat.py
+++ b/scvi/data/anndata/_compat.py
@@ -125,7 +125,7 @@ def manager_from_setup_dict(
         Keyword arguments to modify transfer behavior.
     """
     fields = []
-    setup_kwargs = dict()
+    setup_args = dict()
     data_registry = setup_dict[_constants._DATA_REGISTRY_KEY]
     categorical_mappings = setup_dict["categorical_mappings"]
     for registry_key, adata_mapping in data_registry.items():
@@ -138,15 +138,15 @@ def manager_from_setup_dict(
         attr_key = adata_mapping[_constants._DR_ATTR_KEY]
         if attr_name == _constants._ADATA_ATTRS.X:
             field = LayerField(REGISTRY_KEYS.X_KEY, None)
-            setup_kwargs["layer"] = None
+            setup_args["layer"] = None
         elif attr_name == _constants._ADATA_ATTRS.LAYERS:
             field = LayerField(REGISTRY_KEYS.X_KEY, attr_key)
-            setup_kwargs["layer"] = attr_key
+            setup_args["layer"] = attr_key
         elif attr_name == _constants._ADATA_ATTRS.OBS:
             if new_registry_key in {REGISTRY_KEYS.BATCH_KEY, REGISTRY_KEYS.LABELS_KEY}:
                 original_key = categorical_mappings[attr_key]["original_key"]
                 field = CategoricalObsField(new_registry_key, original_key)
-                setup_kwargs[f"{new_registry_key}_key"] = original_key
+                setup_args[f"{new_registry_key}_key"] = original_key
             elif new_registry_key == REGISTRY_KEYS.INDICES_KEY:
                 adata.obs[attr_key] = np.arange(adata.n_obs).astype("int64")
                 field = NumericalObsField(new_registry_key, attr_key)
@@ -154,11 +154,11 @@ def manager_from_setup_dict(
             if new_registry_key == REGISTRY_KEYS.CONT_COVS_KEY:
                 obs_keys = setup_dict["extra_continuous_keys"]
                 field = NumericalJointObsField(REGISTRY_KEYS.CONT_COVS_KEY, obs_keys)
-                setup_kwargs["continuous_covariate_keys"] = obs_keys
+                setup_args["continuous_covariate_keys"] = obs_keys
             elif new_registry_key == REGISTRY_KEYS.CAT_COVS_KEY:
                 obs_keys = setup_dict["extra_categoricals"]["keys"]
                 field = CategoricalJointObsField(REGISTRY_KEYS.CAT_COVS_KEY, obs_keys)
-                setup_kwargs["categorical_covariate_keys"] = obs_keys
+                setup_args["categorical_covariate_keys"] = obs_keys
             elif new_registry_key == REGISTRY_KEYS.PROTEIN_EXP_KEY:
                 protein_names = setup_dict["protein_names"]
                 adata.uns["_protein_names"] = protein_names
@@ -169,8 +169,8 @@ def manager_from_setup_dict(
                     batch_key="_scvi_batch",
                     colnames_uns_key="_protein_names",
                 )
-                setup_kwargs["protein_expression_obsm_key"] = attr_key
-                setup_kwargs["protein_names_uns_key"] = "_protein_names"
+                setup_args["protein_expression_obsm_key"] = attr_key
+                setup_args["protein_names_uns_key"] = "_protein_names"
             else:
                 raise NotImplementedError(
                     f"Unrecognized .obsm attribute {attr_key} registered as {new_registry_key}. Backwards compatibility unavailable."
@@ -183,7 +183,7 @@ def manager_from_setup_dict(
 
     setup_method_args = {
         _constants._MODEL_NAME_KEY: cls.__name__,
-        _constants._SETUP_KWARGS_KEY: setup_kwargs,
+        _constants._SETUP_ARGS_KEY: setup_args,
     }
     adata_manager = AnnDataManager(fields=fields, setup_method_args=setup_method_args)
 

--- a/scvi/data/anndata/_constants.py
+++ b/scvi/data/anndata/_constants.py
@@ -13,7 +13,7 @@ _MANAGER_UUID_KEY = "_scvi_manager_uuid"
 
 _SCVI_VERSION_KEY = "scvi_version"
 _MODEL_NAME_KEY = "model_name"
-_SETUP_KWARGS_KEY = "setup_kwargs"
+_SETUP_ARGS_KEY = "setup_args"
 _FIELD_REGISTRIES_KEY = "field_registries"
 _DATA_REGISTRY_KEY = "data_registry"
 _STATE_REGISTRY_KEY = "state_registry"

--- a/scvi/data/anndata/_manager.py
+++ b/scvi/data/anndata/_manager.py
@@ -58,7 +58,7 @@ class AnnDataManager:
         self._registry = {
             _constants._SCVI_VERSION_KEY: scvi.__version__,
             _constants._MODEL_NAME_KEY: None,
-            _constants._SETUP_KWARGS_KEY: None,
+            _constants._SETUP_ARGS_KEY: None,
             _constants._FIELD_REGISTRIES_KEY: defaultdict(dict),
         }
         if setup_method_args is not None:
@@ -88,7 +88,7 @@ class AnnDataManager:
         return {
             k: v
             for k, v in self._registry.items()
-            if k in {_constants._MODEL_NAME_KEY, _constants._SETUP_KWARGS_KEY}
+            if k in {_constants._MODEL_NAME_KEY, _constants._SETUP_ARGS_KEY}
         }
 
     def _assign_uuid(self):
@@ -328,10 +328,36 @@ class AnnDataManager:
 
         return t
 
+    @staticmethod
+    def view_setup_method_args(registry: dict) -> None:
+        """
+        Prints setup kwargs used to produce a given registry.
+
+        Parameters
+        ----------
+        registry
+            Registry produced by an AnnDataManager.
+        """
+        model_name = registry[_constants._MODEL_NAME_KEY]
+        setup_args = registry[_constants._SETUP_ARGS_KEY]
+        if model_name is not None and setup_args is not None:
+            rich.print(f"Setup via `{model_name}.setup_anndata` with arguments:")
+            rich.pretty.pprint(setup_args)
+            rich.print()
+
     def view_registry(self, hide_state_registries: bool = False) -> None:
-        """Prints summary of the registry."""
+        """
+        Prints summary of the registry.
+
+        Parameters
+        ----------
+        hide_state_registries
+            If True, prints a shortened summary without details of each state registry.
+        """
         version = self._registry[_constants._SCVI_VERSION_KEY]
-        rich.print("Anndata setup with scvi-tools version {}.".format(version))
+        rich.print(f"Anndata setup with scvi-tools version {version}.")
+        rich.print()
+        self.view_setup_method_args(self._registry)
 
         in_colab = "google.colab" in sys.modules
         force_jupyter = None if not in_colab else True

--- a/scvi/external/gimvi/_model.py
+++ b/scvi/external/gimvi/_model.py
@@ -12,7 +12,7 @@ from torch.utils.data import DataLoader
 from scvi import REGISTRY_KEYS
 from scvi.data.anndata import AnnDataManager
 from scvi.data.anndata._compat import manager_from_setup_dict
-from scvi.data.anndata._constants import _MODEL_NAME_KEY, _SETUP_KWARGS_KEY
+from scvi.data.anndata._constants import _MODEL_NAME_KEY, _SETUP_ARGS_KEY
 from scvi.data.anndata.fields import CategoricalObsField, LayerField
 from scvi.dataloaders import DataSplitter
 from scvi.model._utils import _init_library_size, parse_use_gpu_arg
@@ -525,14 +525,14 @@ class GIMVI(VAEMixin, BaseModelClass):
                         "It appears you are loading a model from a different class."
                     )
 
-                if _SETUP_KWARGS_KEY not in registry:
+                if _SETUP_ARGS_KEY not in registry:
                     raise ValueError(
                         "Saved model does not contain original setup inputs. "
                         "Cannot load the original setup."
                     )
 
                 cls.setup_anndata(
-                    adata, source_registry=registry, **registry[_SETUP_KWARGS_KEY]
+                    adata, source_registry=registry, **registry[_SETUP_ARGS_KEY]
                 )
 
         # get the parameters for the class init signiture

--- a/scvi/model/_scanvi.py
+++ b/scvi/model/_scanvi.py
@@ -208,7 +208,9 @@ class SCANVI(RNASeqMixin, VAEMixin, ArchesMixin, BaseModelClass):
             adata = scvi_model.adata
 
         scvi_setup_kwargs = scvi_model.adata_manager.registry[_SETUP_KWARGS_KEY]
-        cls.setup_anndata(adata, unlabeled_category, **scvi_setup_kwargs)
+        cls.setup_anndata(
+            adata, unlabeled_category=unlabeled_category, **scvi_setup_kwargs
+        )
         scanvi_model = cls(adata, **non_kwargs, **kwargs, **scanvi_kwargs)
         scvi_state_dict = scvi_model.module.state_dict()
         scanvi_model.module.load_state_dict(scvi_state_dict, strict=False)
@@ -382,10 +384,10 @@ class SCANVI(RNASeqMixin, VAEMixin, ArchesMixin, BaseModelClass):
     def setup_anndata(
         cls,
         adata: AnnData,
+        labels_key: str,
         unlabeled_category: Union[str, int, float],
         layer: Optional[str] = None,
         batch_key: Optional[str] = None,
-        labels_key: Optional[str] = None,
         size_factor_key: Optional[str] = None,
         categorical_covariate_keys: Optional[List[str]] = None,
         continuous_covariate_keys: Optional[List[str]] = None,

--- a/scvi/model/_scanvi.py
+++ b/scvi/model/_scanvi.py
@@ -10,7 +10,7 @@ from anndata import AnnData
 from scvi import REGISTRY_KEYS
 from scvi._compat import Literal
 from scvi.data.anndata import AnnDataManager
-from scvi.data.anndata._constants import _SETUP_KWARGS_KEY
+from scvi.data.anndata._constants import _SETUP_ARGS_KEY
 from scvi.data.anndata.fields import (
     CategoricalJointObsField,
     CategoricalObsField,
@@ -207,9 +207,9 @@ class SCANVI(RNASeqMixin, VAEMixin, ArchesMixin, BaseModelClass):
         if adata is None:
             adata = scvi_model.adata
 
-        scvi_setup_kwargs = scvi_model.adata_manager.registry[_SETUP_KWARGS_KEY]
+        scvi_setup_args = scvi_model.adata_manager.registry[_SETUP_ARGS_KEY]
         cls.setup_anndata(
-            adata, unlabeled_category=unlabeled_category, **scvi_setup_kwargs
+            adata, unlabeled_category=unlabeled_category, **scvi_setup_args
         )
         scanvi_model = cls(adata, **non_kwargs, **kwargs, **scanvi_kwargs)
         scvi_state_dict = scvi_model.module.state_dict()

--- a/scvi/model/base/_archesmixin.py
+++ b/scvi/model/base/_archesmixin.py
@@ -8,7 +8,7 @@ from anndata import AnnData
 
 from scvi.data.anndata import _constants
 from scvi.data.anndata._compat import manager_from_setup_dict
-from scvi.data.anndata._constants import _MODEL_NAME_KEY, _SETUP_KWARGS_KEY
+from scvi.data.anndata._constants import _MODEL_NAME_KEY, _SETUP_ARGS_KEY
 from scvi.model._utils import parse_use_gpu_arg
 from scvi.nn import FCLayers
 
@@ -102,7 +102,7 @@ class ArchesMixin:
                     "It appears you are loading a model from a different class."
                 )
 
-            if _SETUP_KWARGS_KEY not in registry:
+            if _SETUP_ARGS_KEY not in registry:
                 raise ValueError(
                     "Saved model does not contain original setup inputs. "
                     "Cannot load the original setup."
@@ -112,7 +112,7 @@ class ArchesMixin:
                 adata,
                 source_registry=registry,
                 extend_categories=True,
-                **registry[_SETUP_KWARGS_KEY]
+                **registry[_SETUP_ARGS_KEY]
             )
 
         model = _initialize_model(cls, adata, attr_dict)

--- a/scvi/model/base/_base_model.py
+++ b/scvi/model/base/_base_model.py
@@ -649,7 +649,8 @@ class BaseModelClass(metaclass=BaseModelMetaClass):
         # Legacy support for old setup dict format.
         if "scvi_setup_dict_" in attr_dict:
             raise NotImplementedError(
-                "Viewing setup args for pre v0.15.0 models is unsupported."
+                "Viewing setup args for pre v0.15.0 models is unsupported. "
+                "Load and resave the model to use this function."
             )
 
         registry = attr_dict.pop("registry_")

--- a/scvi/model/base/_base_model.py
+++ b/scvi/model/base/_base_model.py
@@ -114,7 +114,6 @@ class BaseModelClass(metaclass=BaseModelMetaClass):
         Must be called with ``**locals()`` at the start of the ``setup_anndata`` method
         to avoid the inclusion of any extraneous variables.
         """
-        setup_locals.pop("adata")
         cls = setup_locals.pop("cls")
         model_name = cls.__name__
         setup_args = dict()
@@ -634,15 +633,27 @@ class BaseModelClass(metaclass=BaseModelMetaClass):
         """
 
     @staticmethod
-    def view_setup_args(source: Union[Type["BaseModelClass"], str, dict]) -> None:
+    def view_setup_args(dir_path: str, prefix: Optional[str] = None) -> None:
         """
         Print args used to setup a saved model.
 
         Parameters
         ----------
-        source
-            Model instance, model save dir path, or model registry.
+        dir_path
+            Path to saved outputs.
+        prefix
+            Prefix of saved file names.
         """
+        attr_dict = _load_saved_files(dir_path, False, prefix=prefix)[0]
+
+        # Legacy support for old setup dict format.
+        if "scvi_setup_dict_" in attr_dict:
+            raise NotImplementedError(
+                "Viewing setup args for pre v0.15.0 models is unsupported."
+            )
+
+        registry = attr_dict.pop("registry_")
+        AnnDataManager.view_setup_method_args(registry)
 
     def view_anndata_setup(
         self, adata: Optional[AnnData] = None, hide_state_registries: bool = False

--- a/tests/dataset/utils.py
+++ b/tests/dataset/utils.py
@@ -5,6 +5,7 @@ from anndata import AnnData
 
 from scvi import REGISTRY_KEYS
 from scvi.data.anndata import AnnDataManager
+from scvi.data.anndata._constants import _MODEL_NAME_KEY, _SETUP_ARGS_KEY
 from scvi.data.anndata.fields import (
     CategoricalJointObsField,
     CategoricalObsField,
@@ -39,6 +40,10 @@ def generic_setup_adata_manager(
     protein_expression_obsm_key: Optional[str] = None,
     protein_names_uns_key: Optional[str] = None,
 ) -> AnnDataManager:
+    setup_args = locals()
+    setup_args.pop("adata")
+    setup_method_args = {_MODEL_NAME_KEY: "TestModel", _SETUP_ARGS_KEY: setup_args}
+
     batch_field = CategoricalObsField(REGISTRY_KEYS.BATCH_KEY, batch_key)
     anndata_fields = [
         batch_field,
@@ -60,6 +65,8 @@ def generic_setup_adata_manager(
                 is_count_data=True,
             )
         )
-    adata_manager = AnnDataManager(fields=anndata_fields)
+    adata_manager = AnnDataManager(
+        fields=anndata_fields, setup_method_args=setup_method_args
+    )
     adata_manager.register_fields(adata)
     return adata_manager

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -451,7 +451,7 @@ def test_saving_and_loading(save_path):
         np.testing.assert_array_equal(p1, p2)
         assert model.is_trained is True
 
-    SCANVI.setup_anndata(adata, "label_0", batch_key="batch", labels_key="labels")
+    SCANVI.setup_anndata(adata, "labels", "label_0", batch_key="batch")
     test_save_load_scanvi(legacy=True)
     test_save_load_scanvi()
     # Test load prioritizes newer save paradigm and thus mismatches legacy save.
@@ -721,9 +721,9 @@ def test_scanvi(save_path):
     adata = synthetic_iid()
     SCANVI.setup_anndata(
         adata,
+        "labels",
         "label_0",
         batch_key="batch",
-        labels_key="labels",
     )
     model = SCANVI(adata, n_latent=10)
     model.train(1, train_size=0.5, check_val_every_n_epoch=1)
@@ -750,7 +750,10 @@ def test_scanvi(save_path):
     unknown_label = "asdf"
     a = scvi.data.synthetic_iid()
     scvi.model.SCANVI.setup_anndata(
-        a, unknown_label, batch_key="batch", labels_key="labels"
+        a,
+        "labels",
+        unknown_label,
+        batch_key="batch",
     )
     m = scvi.model.SCANVI(a)
     m.train(1)
@@ -759,7 +762,10 @@ def test_scanvi(save_path):
     unknown_label = "label_0"
     a = scvi.data.synthetic_iid()
     scvi.model.SCANVI.setup_anndata(
-        a, unknown_label, batch_key="batch", labels_key="labels"
+        a,
+        "labels",
+        unknown_label,
+        batch_key="batch",
     )
     m = scvi.model.SCANVI(a)
     m.train(1, train_size=0.9)
@@ -1069,9 +1075,9 @@ def test_multiple_covariates_scvi(save_path):
 
     SCANVI.setup_anndata(
         adata,
+        "labels",
         "Unknown",
         batch_key="batch",
-        labels_key="labels",
         continuous_covariate_keys=["cont1", "cont2"],
         categorical_covariate_keys=["cat1", "cat2"],
     )

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -345,6 +345,7 @@ def test_saving_and_loading(save_path):
             )
         else:
             model.save(save_path, overwrite=True, save_anndata=True, prefix=prefix)
+            model.view_setup_args(save_path, prefix=prefix)
         model = cls.load(save_path, prefix=prefix)
         model.get_latent_representation()
 
@@ -401,6 +402,7 @@ def test_saving_and_loading(save_path):
             )
         else:
             model.save(save_path, overwrite=True, save_anndata=True, prefix=prefix)
+            model.view_setup_args(save_path, prefix=prefix)
         model = AUTOZI.load(save_path, prefix=prefix)
         model.get_latent_representation()
         tmp_adata = scvi.data.synthetic_iid(n_genes=200)
@@ -436,6 +438,7 @@ def test_saving_and_loading(save_path):
             )
         else:
             model.save(save_path, overwrite=True, save_anndata=True, prefix=prefix)
+            model.view_setup_args(save_path, prefix=prefix)
         model = SCANVI.load(save_path, prefix=prefix)
         model.get_latent_representation()
         tmp_adata = scvi.data.synthetic_iid(n_genes=200)

--- a/tests/models/test_scarches.py
+++ b/tests/models/test_scarches.py
@@ -166,7 +166,7 @@ def test_scanvi_online_update(save_path):
     new_labels = adata1.obs.labels.to_numpy()
     new_labels[0] = "Unknown"
     adata1.obs["labels"] = pd.Categorical(new_labels)
-    SCANVI.setup_anndata(adata1, "Unknown", batch_key="batch", labels_key="labels")
+    SCANVI.setup_anndata(adata1, "labels", "Unknown", batch_key="batch")
     model = SCANVI(
         adata1,
         n_latent=n_latent,
@@ -200,7 +200,7 @@ def test_scanvi_online_update(save_path):
     adata1 = synthetic_iid()
     new_labels = adata1.obs.labels.to_numpy()
     adata1.obs["labels"] = pd.Categorical(new_labels)
-    SCANVI.setup_anndata(adata1, "Unknown", batch_key="batch", labels_key="labels")
+    SCANVI.setup_anndata(adata1, "labels", "Unknown", batch_key="batch")
     model = SCANVI(adata1, n_latent=n_latent, encode_covariates=True)
     model.train(max_epochs=1, check_val_every_n_epoch=1)
     dir_path = os.path.join(save_path, "saved_model/")
@@ -263,7 +263,7 @@ def test_scanvi_online_update(save_path):
     # test saving and loading of online scanvi
     a = synthetic_iid()
     ref = a[a.obs["labels"] != "label_2"].copy()  # only has labels 0 and 1
-    SCANVI.setup_anndata(ref, "label_2", batch_key="batch", labels_key="labels")
+    SCANVI.setup_anndata(ref, "labels", "label_2", batch_key="batch")
     m = SCANVI(ref)
     m.train(max_epochs=1)
     m.save(save_path, overwrite=True)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/14086852/153975423-00ecdf3b-c0f0-4355-872c-f2011c885c37.png)

Necessary to replace former `view_anndata_setup` functionality for saved model paths. Handy when working with transfer learning.