### PR TITLE
JaxSCVI

### DIFF
--- a/docs/api/developer.rst
+++ b/docs/api/developer.rst
@@ -115,7 +115,6 @@ Existing module classes with respective generative and inference procedures.
    module.VAE
    module.VAEC
    module.AmortizedLDAPyroModule
-   module.JaxVAE
 
 
 External module

--- a/docs/api/developer.rst
+++ b/docs/api/developer.rst
@@ -115,6 +115,7 @@ Existing module classes with respective generative and inference procedures.
    module.VAE
    module.VAEC
    module.AmortizedLDAPyroModule
+   module.JaxVAE
 
 
 External module

--- a/docs/api/user.rst
+++ b/docs/api/user.rst
@@ -31,6 +31,7 @@ Model
    model.TOTALVI
    model.MULTIVI
    model.AmortizedLDA
+   model.JaxSCVI
 
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -99,6 +99,8 @@ intersphinx_mapping = dict(
     pytorch_lightning=("https://pytorch-lightning.readthedocs.io/en/stable/", None),
     pyro=("http://docs.pyro.ai/en/stable/", None),
     pymde=("https://pymde.org/", None),
+    flax=("https://flax.readthedocs.io/en/latest/", None),
+    jax=("https://jax.readthedocs.io/en/latest/", None),
 )
 
 

--- a/docs/release_notes/v0.15.0.rst
+++ b/docs/release_notes/v0.15.0.rst
@@ -20,6 +20,8 @@ for scvi-tools and stores necessary information, rather than adding additional f
    :alt: Schematic of data handling strategy with AnnDataManager
 
    Schematic of data handling strategy with :class:`~scvi.data.AnnDataManager`
+   
+We also have an exciting new experimental Jax-based scVI implementation via :class:`~scvi.model.JaxSCVI`. While this implementation has limited functionality, we have found it to be substantially faster than the PyTorch-based implementation. For example, on a 10-core Intel CPU, Jax on only a CPU can be as fast as PyTorch with a GPU (RTX3090). We will be planning further Jax integrations in the next releases.
 
 Changes
 ~~~~~~~
@@ -32,6 +34,7 @@ Changes
 - Fix for :class:`~scvi.external.SOLO` when :class:`~scvi.model.SCVI` was setup with a `labels_key` (`#1354`_)
 - Updates to tutorials (`#1369`_, `#1371`_)
 - Furo docs theme (`#1290`_)
+- Add :class:`scvi.model.JaxSCVI` and :class:`scvi.model.JaxSCVI` :class:`scvi.module.JaxVAE` (`#1367`_).
 
 Breaking changes
 ~~~~~~~~~~~~~~~~
@@ -75,3 +78,5 @@ Contributors
 .. _`#1369`: https://github.com/YosefLab/scvi-tools/pull/1369
 .. _`#1371`: https://github.com/YosefLab/scvi-tools/pull/1371
 .. _`#1290`: https://github.com/YosefLab/scvi-tools/pull/1290
+.. _`#1367`: https://github.com/YosefLab/scvi-tools/pull/1367
+

--- a/docs/release_notes/v0.15.0.rst
+++ b/docs/release_notes/v0.15.0.rst
@@ -34,7 +34,7 @@ Changes
 - Fix for :class:`~scvi.external.SOLO` when :class:`~scvi.model.SCVI` was setup with a `labels_key` (`#1354`_)
 - Updates to tutorials (`#1369`_, `#1371`_)
 - Furo docs theme (`#1290`_)
-- Add :class:`scvi.model.JaxSCVI` and :class:`scvi.model.JaxSCVI` :class:`scvi.module.JaxVAE` (`#1367`_).
+- Add :class:`scvi.model.JaxSCVI` and :class:`scvi.module.JaxVAE`, drop Numba dependency for checking if data is count data (`#1367`_).
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ importlib-metadata = {version = "^1.0", python = "<3.8"}
 ipython = {version = ">=7.20", optional = true, python = ">=3.7"}
 ipywidgets = "*"
 isort = {version = ">=5.7", optional = true}
+jax = {version = "*", extras = ["cpu"]}
 jupyter = {version = ">=1.0", optional = true}
 leidenalg = {version = "*", optional = true}
 loompy = {version = ">=3.0.6", optional = true}
@@ -50,7 +51,9 @@ nbsphinx = {version = "*", optional = true}
 nbsphinx-link = {version = "*", optional = true}
 numba = ">=0.41.0"
 numpy = ">=1.17.0"
+numpyro = "*"
 openpyxl = ">=3.0"
+optax = "*"
 pandas = ">=1.0"
 pre-commit = {version = ">=2.7.1", optional = true}
 pymde = {version = "*", optional = true}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ importlib-metadata = {version = "^1.0", python = "<3.8"}
 ipython = {version = ">=7.20", optional = true, python = ">=3.7"}
 ipywidgets = "*"
 isort = {version = ">=5.7", optional = true}
-jax = {version = "*", extras = ["cpu"]}
+jax = ">=0.3"
 jupyter = {version = ">=1.0", optional = true}
 leidenalg = {version = "*", optional = true}
 loompy = {version = ">=3.0.6", optional = true}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ black = {version = ">=22.1", optional = true}
 codecov = {version = ">=2.0.8", optional = true}
 docrep = ">=0.3.2"
 flake8 = {version = ">=3.7.7", optional = true}
+flax = "*"
 furo = {version = ">=2022.2.14.1", optional = true}
 h5py = ">=2.9.0"
 importlib-metadata = {version = "^1.0", python = "<3.8"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,6 @@ nbconvert = {version = ">=5.4.0", optional = true}
 nbformat = {version = ">=4.4.0", optional = true}
 nbsphinx = {version = "*", optional = true}
 nbsphinx-link = {version = "*", optional = true}
-numba = ">=0.41.0"
 numpy = ">=1.17.0"
 numpyro = "*"
 openpyxl = ">=3.0"

--- a/scvi/_settings.py
+++ b/scvi/_settings.py
@@ -216,7 +216,7 @@ class ScviConfig:
         if value is False:
             os.environ["XLA_PYTHON_CLIENT_PREALLOCATE"] = "false"
         elif isinstance(value, float):
-            if value > 0.99 or value < 0:
+            if value >= 1 or value <= 0:
                 raise ValueError("Need to use a value between 0 and 1")
             # format is ".XX"
             os.environ["XLA_PYTHON_CLIENT_MEM_FRACTION"] = str(value)[1:4]

--- a/scvi/_settings.py
+++ b/scvi/_settings.py
@@ -57,7 +57,6 @@ class ScviConfig:
         jax_preallocate_gpu_memory: bool = False,
     ):
 
-        self.verbosity = verbosity
         self.seed = seed
         self.batch_size = batch_size
         if progress_bar_style not in ["rich", "tqdm"]:
@@ -68,6 +67,7 @@ class ScviConfig:
         self.dl_pin_memory_gpu_training = dl_pin_memory_gpu_training
         self._num_threads = None
         self.jax_preallocate_gpu_memory = jax_preallocate_gpu_memory
+        self.verbosity = verbosity
 
     @property
     def batch_size(self) -> int:
@@ -178,7 +178,9 @@ class ScviConfig:
             console = Console(force_terminal=True)
             if console.is_jupyter is True:
                 console.is_jupyter = False
-            ch = RichHandler(show_path=False, console=console, show_time=False)
+            ch = RichHandler(
+                level=level, show_path=False, console=console, show_time=False
+            )
             formatter = logging.Formatter("%(message)s")
             ch.setFormatter(formatter)
             scvi_logger.addHandler(ch)
@@ -192,7 +194,7 @@ class ScviConfig:
         This is useful if piping outputs to a file.
         """
         scvi_logger.removeHandler(scvi_logger.handlers[0])
-        ch = RichHandler(show_path=False, show_time=False)
+        ch = RichHandler(level=self._verbosity, show_path=False, show_time=False)
         formatter = logging.Formatter("%(message)s")
         ch.setFormatter(formatter)
         scvi_logger.addHandler(ch)

--- a/scvi/data/_utils.py
+++ b/scvi/data/_utils.py
@@ -203,7 +203,7 @@ def _check_nonnegative_integers(
 
 
 @jax.jit
-def _is_count(data: jnp.ndarray):
+def _is_not_count_val(data: jnp.ndarray):
     negative = jnp.any(data < 0)
     non_integer = jnp.any(data % 1 != 0)
 

--- a/scvi/data/_utils.py
+++ b/scvi/data/_utils.py
@@ -198,7 +198,7 @@ def _check_nonnegative_integers(
 
     inds = np.random.choice(len(data), size=(n_to_check,))
     check = jax.device_put(data.flat[inds], device=jax.devices("cpu")[0])
-    negative, non_integer = _is_count(check)
+    negative, non_integer = _is_not_count_val(check)
     return not (negative or non_integer)
 
 

--- a/scvi/data/_utils.py
+++ b/scvi/data/_utils.py
@@ -178,7 +178,8 @@ def _assign_adata_uuid(adata: anndata.AnnData, overwrite: bool = False) -> None:
 
 
 def _check_nonnegative_integers(
-    data: Union[pd.DataFrame, np.ndarray, sp_sparse.spmatrix, h5py.Dataset]
+    data: Union[pd.DataFrame, np.ndarray, sp_sparse.spmatrix, h5py.Dataset],
+    n_to_check: int = 20,
 ):
     """Approximately checks values of data to ensure it is count data."""
 
@@ -195,8 +196,7 @@ def _check_nonnegative_integers(
     else:
         raise TypeError("data type not understood")
 
-    n = len(data)
-    inds = np.random.permutation(n)[:20]
+    inds = np.random.choice(data, size=(n_to_check,))
     check = jax.device_put(data.flat[inds], device=jax.devices("cpu")[0])
     negative, non_integer = _is_count(check)
     return not (negative or non_integer)

--- a/scvi/data/_utils.py
+++ b/scvi/data/_utils.py
@@ -196,7 +196,7 @@ def _check_nonnegative_integers(
     else:
         raise TypeError("data type not understood")
 
-    inds = np.random.choice(data, size=(n_to_check,))
+    inds = np.random.choice(len(data), size=(n_to_check,))
     check = jax.device_put(data.flat[inds], device=jax.devices("cpu")[0])
     negative, non_integer = _is_count(check)
     return not (negative or non_integer)

--- a/scvi/dataloaders/_ann_dataloader.py
+++ b/scvi/dataloaders/_ann_dataloader.py
@@ -106,6 +106,8 @@ class AnnDataLoader(DataLoader):
         If ``None``, defaults to all registered data.
     data_loader_kwargs
         Keyword arguments for :class:`~torch.utils.data.DataLoader`
+    iter_ndarray
+        Whether to iterate over numpy arrays instead of torch tensors
     """
 
     def __init__(
@@ -116,6 +118,7 @@ class AnnDataLoader(DataLoader):
         batch_size=128,
         data_and_attributes: Optional[dict] = None,
         drop_last: Union[bool, int] = False,
+        iter_ndarray: bool = False,
         **data_loader_kwargs,
     ):
 
@@ -158,4 +161,12 @@ class AnnDataLoader(DataLoader):
         # do not touch batch size here, sampler gives batched indices
         self.data_loader_kwargs.update({"sampler": sampler, "batch_size": None})
 
+        if iter_ndarray:
+            self.data_loader_kwargs.update({"collate_fn": _dummy_collate})
+
         super().__init__(self.dataset, **self.data_loader_kwargs)
+
+
+def _dummy_collate(b):
+    """Dummy collate to have dataloader return numpy ndarrays."""
+    return b

--- a/scvi/model/__init__.py
+++ b/scvi/model/__init__.py
@@ -3,6 +3,7 @@ from ._amortizedlda import AmortizedLDA
 from ._autozi import AUTOZI
 from ._condscvi import CondSCVI
 from ._destvi import DestVI
+from ._jaxscvi import JaxSCVI
 from ._linear_scvi import LinearSCVI
 from ._multivi import MULTIVI
 from ._peakvi import PEAKVI
@@ -22,4 +23,5 @@ __all__ = [
     "MULTIVI",
     "AmortizedLDA",
     "utils",
+    "JaxSCVI",
 ]

--- a/scvi/model/_jaxscvi.py
+++ b/scvi/model/_jaxscvi.py
@@ -1,0 +1,296 @@
+import logging
+from typing import List, Optional, Union
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import numpyro.distributions as dist
+import optax
+import tqdm
+from anndata import AnnData
+from flax.training import train_state
+from jax import random
+
+from scvi import REGISTRY_KEYS
+from scvi._compat import Literal
+from scvi.data.anndata import AnnDataManager
+from scvi.data.anndata.fields import (
+    CategoricalJointObsField,
+    CategoricalObsField,
+    LayerField,
+    NumericalJointObsField,
+    NumericalObsField,
+)
+from scvi.dataloaders import DataSplitter
+from scvi.model._utils import _init_library_size
+from scvi.module import JaxVAE
+from scvi.utils import setup_anndata_dsp
+
+from .base import BaseModelClass
+
+logger = logging.getLogger(__name__)
+
+
+class JaxSCVI(BaseModelClass):
+    """
+    single-cell Variational Inference [Lopez18]_, but with a Jax backend.
+
+    Parameters
+    ----------
+    adata
+        AnnData object that has been registered via :meth:`~scvi.model.SCVI.setup_anndata`.
+    n_hidden
+        Number of nodes per hidden layer.
+    n_latent
+        Dimensionality of the latent space.
+    n_layers
+        Number of hidden layers used for encoder and decoder NNs.
+    dropout_rate
+        Dropout rate for neural networks.
+    dispersion
+        One of the following:
+
+        * ``'gene'`` - dispersion parameter of NB is constant per gene across cells
+        * ``'gene-batch'`` - dispersion can differ between different batches
+        * ``'gene-label'`` - dispersion can differ between different labels
+        * ``'gene-cell'`` - dispersion can differ for every gene in every cell
+    gene_likelihood
+        One of:
+
+        * ``'nb'`` - Negative binomial distribution
+        * ``'zinb'`` - Zero-inflated negative binomial distribution
+        * ``'poisson'`` - Poisson distribution
+    latent_distribution
+        One of:
+
+        * ``'normal'`` - Normal distribution
+        * ``'ln'`` - Logistic normal distribution (Normal(0, I) transformed by softmax)
+    **model_kwargs
+        Keyword args for :class:`~scvi.module.JaxVAE`
+
+    Examples
+    --------
+    >>> adata = anndata.read_h5ad(path_to_anndata)
+    >>> scvi.model.JaxSCVI.setup_anndata(adata, batch_key="batch")
+    >>> vae = scvi.model.SCVI(adata)
+    >>> vae.train()
+    >>> adata.obsm["X_scVI"] = vae.get_latent_representation()
+    >>> adata.obsm["X_normalized_scVI"] = vae.get_normalized_expression()
+    """
+
+    def __init__(
+        self,
+        adata: AnnData,
+        n_hidden: int = 128,
+        n_latent: int = 10,
+        n_layers: int = 1,
+        dropout_rate: float = 0.1,
+        dispersion: Literal["gene", "gene-batch", "gene-label", "gene-cell"] = "gene",
+        gene_likelihood: Literal["zinb", "nb", "poisson"] = "zinb",
+        latent_distribution: Literal["normal", "ln"] = "normal",
+        **model_kwargs,
+    ):
+        super().__init__(adata)
+
+        n_cats_per_cov = (
+            self.adata_manager.get_state_registry(
+                REGISTRY_KEYS.CAT_COVS_KEY
+            ).n_cats_per_key
+            if REGISTRY_KEYS.CAT_COVS_KEY in self.adata_manager.data_registry
+            else None
+        )
+        n_batch = self.summary_stats.n_batch
+        use_size_factor_key = (
+            REGISTRY_KEYS.SIZE_FACTOR_KEY in self.adata_manager.data_registry
+        )
+        library_log_means, library_log_vars = None, None
+        if not use_size_factor_key:
+            library_log_means, library_log_vars = _init_library_size(
+                self.adata_manager, n_batch
+            )
+
+        self.module_kwargs = dict(
+            n_input=self.summary_stats.n_vars,
+            n_batch=n_batch,
+            n_hidden=n_hidden,
+            n_latent=n_latent,
+            n_layers=n_layers,
+            dropout_rate=dropout_rate,
+        )
+        self.module_kwargs.update(model_kwargs)
+        self._module = None
+
+        self._model_summary_string = (
+            "SCVI Model with the following params: \nn_hidden: {}, n_latent: {}, n_layers: {}, dropout_rate: "
+            "{}, dispersion: {}, gene_likelihood: {}, latent_distribution: {}"
+        ).format(
+            n_hidden,
+            n_latent,
+            n_layers,
+            dropout_rate,
+            dispersion,
+            gene_likelihood,
+            latent_distribution,
+        )
+        self.init_params_ = self._get_init_params(locals())
+
+    @classmethod
+    @setup_anndata_dsp.dedent
+    def setup_anndata(
+        cls,
+        adata: AnnData,
+        layer: Optional[str] = None,
+        batch_key: Optional[str] = None,
+        labels_key: Optional[str] = None,
+        size_factor_key: Optional[str] = None,
+        categorical_covariate_keys: Optional[List[str]] = None,
+        continuous_covariate_keys: Optional[List[str]] = None,
+        **kwargs,
+    ):
+        """
+        %(summary)s.
+
+        Parameters
+        ----------
+        %(param_layer)s
+        %(param_batch_key)s
+        %(param_labels_key)s
+        %(param_size_factor_key)s
+        %(param_cat_cov_keys)s
+        %(param_cont_cov_keys)s
+        """
+        setup_method_args = cls._get_setup_method_args(**locals())
+        anndata_fields = [
+            LayerField(REGISTRY_KEYS.X_KEY, layer, is_count_data=True),
+            CategoricalObsField(REGISTRY_KEYS.BATCH_KEY, batch_key),
+            CategoricalObsField(REGISTRY_KEYS.LABELS_KEY, labels_key),
+            NumericalObsField(
+                REGISTRY_KEYS.SIZE_FACTOR_KEY, size_factor_key, required=False
+            ),
+            CategoricalJointObsField(
+                REGISTRY_KEYS.CAT_COVS_KEY, categorical_covariate_keys
+            ),
+            NumericalJointObsField(
+                REGISTRY_KEYS.CONT_COVS_KEY, continuous_covariate_keys
+            ),
+        ]
+        adata_manager = AnnDataManager(
+            fields=anndata_fields, setup_method_args=setup_method_args
+        )
+        adata_manager.register_fields(adata, **kwargs)
+        cls.register_manager(adata_manager)
+
+    def _get_module(self, kwargs=None):
+        if kwargs is None:
+            kwargs = self.module_kwargs
+        return JaxVAE(**kwargs)
+
+    @property
+    def module(self):
+        if self._module is None:
+            self._module = self._get_module()
+        return self._module
+
+    def train(
+        self,
+        max_epochs: Optional[int] = None,
+        use_gpu: Optional[Union[str, int, bool]] = None,
+        train_size: float = 0.9,
+        validation_size: Optional[float] = None,
+        batch_size: int = 128,
+        **trainer_kwargs,
+    ):
+        """
+        Train the model.
+
+        Parameters
+        ----------
+        max_epochs
+            Number of passes through the dataset. If `None`, defaults to
+            `np.min([round((20000 / n_cells) * 400), 400])`
+        use_gpu
+            Use default GPU if available (if None or True), or index of GPU to use (if int),
+            or name of GPU (if str, e.g., `'cuda:0'`), or use CPU (if False).
+        train_size
+            Size of training set in the range [0.0, 1.0].
+        validation_size
+            Size of the test set. If `None`, defaults to 1 - `train_size`. If
+            `train_size + validation_size < 1`, the remaining cells belong to a test set.
+        batch_size
+            Minibatch size to use during training.
+        **trainer_kwargs
+            Other keyword args for :class:`~scvi.train.Trainer`.
+        """
+        if max_epochs is None:
+            n_cells = self.adata.n_obs
+            max_epochs = np.min([round((20000 / n_cells) * 400), 400])
+
+        data_splitter = DataSplitter(
+            self.adata_manager,
+            train_size=train_size,
+            validation_size=validation_size,
+            batch_size=batch_size,
+            use_gpu=use_gpu,
+            iter_ndarray=True,
+        )
+        data_splitter.setup()
+        train_loader = data_splitter.train_dataloader()
+
+        rng = jax.random.PRNGKey(0)
+        rng, init_rng = jax.random.split(rng)
+
+        module = self.module
+
+        params = module.init(rng, next(iter(train_loader)), rng)["params"]
+
+        state = train_state.TrainState.create(
+            apply_fn=module.apply,
+            params=params,
+            tx=optax.adam(1e-3),
+        )
+
+        @jax.jit
+        def train_step(state, array_dict, z_rng, kl_weight=1) -> jnp.ndarray:
+            """ELBO loss: E_p[log(x)] - KL(d||q), where p ~ Be(0.5) and q ~ N(0,1)."""
+            x = array_dict[REGISTRY_KEYS.X_KEY]
+
+            def loss_fn(params):
+                outputs = module.apply({"params": params}, array_dict, z_rng)
+                log_likelihood = outputs.nb.log_prob(x).sum(-1)
+                mean = outputs.mean
+                scale = outputs.stddev
+                prior = dist.Normal(jnp.zeros_like(mean), jnp.ones_like(scale))
+                posterior = dist.Normal(mean, scale)
+                kl = dist.kl_divergence(posterior, prior).sum(-1)
+                elbo = log_likelihood - kl_weight * kl
+                return -jnp.mean(elbo)
+
+            value, grads = jax.value_and_grad(loss_fn)(state.params)
+            state = state.apply_gradients(grads=grads)
+            return state, value
+
+        history = []
+        epoch = 0
+        with tqdm.trange(1, max_epochs + 1) as t:
+            for i in t:
+                epoch += 1
+                epoch_loss = 0
+                counter = 0
+                for data in train_loader:
+                    kl_weight = min(1.0, epoch / 400.0)
+                    rng, key = random.split(rng)
+                    state, value = train_step(state, data, key, kl_weight=kl_weight)
+                    epoch_loss += value
+                    counter += 1
+                history += [epoch_loss / counter]
+                t.set_postfix_str(
+                    f"Epoch {i}, Loss: {epoch_loss / counter}, KL weight: {kl_weight}"
+                )
+
+        self.train_state = state
+        self.params = state.params
+        self.history_ = history
+
+    def get_latent_representation(self):
+
+        pass

--- a/scvi/model/_jaxscvi.py
+++ b/scvi/model/_jaxscvi.py
@@ -14,8 +14,8 @@ from jax import random
 
 from scvi import REGISTRY_KEYS
 from scvi._compat import Literal
-from scvi.data.anndata import AnnDataManager
-from scvi.data.anndata.fields import (
+from scvi.data import AnnDataManager
+from scvi.data.fields import (
     CategoricalJointObsField,
     CategoricalObsField,
     LayerField,

--- a/scvi/model/_jaxscvi.py
+++ b/scvi/model/_jaxscvi.py
@@ -268,6 +268,7 @@ class JaxSCVI(BaseModelClass):
             x = array_dict[REGISTRY_KEYS.X_KEY]
             rngs = {k: random.split(v)[1] for k, v in rngs.items()}
 
+            # batch stats can't be passed here
             def loss_fn(params):
                 vars_in = {"params": params, "batch_stats": state.batch_stats}
                 outputs, new_model_state = state.apply_fn(

--- a/scvi/model/_jaxscvi.py
+++ b/scvi/model/_jaxscvi.py
@@ -37,7 +37,7 @@ class JaxSCVI(BaseModelClass):
     Parameters
     ----------
     adata
-        AnnData object that has been registered via :meth:`~scvi.model.SCVI.setup_anndata`.
+        AnnData object that has been registered via :meth:`~scvi.model.JaxSCVI.setup_anndata`.
     n_hidden
         Number of nodes per hidden layer.
     n_latent

--- a/scvi/model/_jaxscvi.py
+++ b/scvi/model/_jaxscvi.py
@@ -17,7 +17,6 @@ from scvi._compat import Literal
 from scvi.data import AnnDataManager
 from scvi.data.fields import CategoricalObsField, LayerField
 from scvi.dataloaders import DataSplitter
-from scvi.model._utils import _init_library_size
 from scvi.module import JaxVAE
 from scvi.utils import setup_anndata_dsp
 
@@ -74,22 +73,7 @@ class JaxSCVI(BaseModelClass):
     ):
         super().__init__(adata)
 
-        n_cats_per_cov = (
-            self.adata_manager.get_state_registry(
-                REGISTRY_KEYS.CAT_COVS_KEY
-            ).n_cats_per_key
-            if REGISTRY_KEYS.CAT_COVS_KEY in self.adata_manager.data_registry
-            else None
-        )
         n_batch = self.summary_stats.n_batch
-        use_size_factor_key = (
-            REGISTRY_KEYS.SIZE_FACTOR_KEY in self.adata_manager.data_registry
-        )
-        library_log_means, library_log_vars = None, None
-        if not use_size_factor_key:
-            library_log_means, library_log_vars = _init_library_size(
-                self.adata_manager, n_batch
-            )
 
         self.module_kwargs = dict(
             n_input=self.summary_stats.n_vars,
@@ -339,4 +323,4 @@ class JaxSCVI(BaseModelClass):
 
     @property
     def device(self):
-        pass
+        raise NotImplementedError

--- a/scvi/module/__init__.py
+++ b/scvi/module/__init__.py
@@ -1,6 +1,7 @@
 from ._amortizedlda import AmortizedLDAPyroModule
 from ._autozivae import AutoZIVAE
 from ._classifier import Classifier
+from ._jaxvae import JaxVAE
 from ._mrdeconv import MRDeconv
 from ._multivae import MULTIVAE
 from ._peakvae import PEAKVAE
@@ -21,4 +22,5 @@ __all__ = [
     "MRDeconv",
     "MULTIVAE",
     "AmortizedLDAPyroModule",
+    "JaxVAE",
 ]

--- a/scvi/module/_jaxvae.py
+++ b/scvi/module/_jaxvae.py
@@ -99,6 +99,7 @@ class JaxVAE(nn.Module):
     is_training: bool = False
     n_layers: int = 1
     gene_likelihood: str = "nb"
+    eps: float = 1e-8
 
     @nn.compact
     def __call__(self, array_dict) -> VAEOutput:
@@ -114,7 +115,7 @@ class JaxVAE(nn.Module):
             n_hidden=self.n_hidden,
             dropout_rate=self.dropout_rate,
         )(x, self.is_training)
-        stddev = jnp.sqrt(var) + 1e-4
+        stddev = jnp.sqrt(var) + self.eps
 
         qz = dist.Normal(mean, stddev)
         z_rng = self.make_rng("z")
@@ -130,7 +131,7 @@ class JaxVAE(nn.Module):
         mu = total_count * rho
 
         if self.gene_likelihood == "nb":
-            nb_logits = jnp.log(mu + 1e-6) - jnp.log(disp_ + 1e-6)
+            nb_logits = jnp.log(mu + self.eps) - jnp.log(disp_ + self.eps)
             disp_ = jnp.exp(disp)
             px = dist.NegativeBinomialLogits(logits=nb_logits, total_count=disp_)
         else:

--- a/scvi/module/_jaxvae.py
+++ b/scvi/module/_jaxvae.py
@@ -43,9 +43,9 @@ class FlaxEncoder(nn.Module):
         h = nn.Dropout(self.dropout_rate)(h, deterministic=not is_training)
 
         mean = Dense(self.n_latent)(h)
-        log_concentration = Dense(self.n_latent)(h)
+        log_var = Dense(self.n_latent)(h)
 
-        return mean, nn.softplus(log_concentration)
+        return mean, jnp.exp(log_var)
 
 
 class FlaxDecoder(nn.Module):
@@ -56,7 +56,9 @@ class FlaxDecoder(nn.Module):
 
     @nn.compact
     def __call__(self, z, batch, is_training):
-        disp = self.param("disp", lambda rng, shape: jnp.ones(shape), (self.n_input, 1))
+        disp = self.param(
+            "disp", lambda rng, shape: jax.random.normal(rng, shape), (self.n_input, 1)
+        )
         is_training = nn.merge_param("is_training", self.is_training, is_training)
         h = Dense(self.n_hidden)(z)
         h += Dense(self.n_hidden)(batch)

--- a/scvi/module/_jaxvae.py
+++ b/scvi/module/_jaxvae.py
@@ -34,17 +34,11 @@ class FlaxEncoder(nn.Module):
         inputs_ = jnp.log1p(inputs)
 
         h = Dense(self.n_hidden)(inputs_)
-        h = nn.LayerNorm(
-            use_scale=False,
-            use_bias=False,
-        )(h)
+        h = nn.BatchNorm(momentum=0.9)(h, use_running_average=not is_training)
         h = nn.relu(h)
         h = nn.Dropout(self.dropout_rate)(h, deterministic=not is_training)
         h = Dense(self.n_hidden)(h)
-        h = nn.LayerNorm(
-            use_scale=False,
-            use_bias=False,
-        )(h)
+        h = nn.BatchNorm(momentum=0.9)(h, use_running_average=not is_training)
         h = nn.relu(h)
         h = nn.Dropout(self.dropout_rate)(h, deterministic=not is_training)
 
@@ -67,18 +61,13 @@ class FlaxDecoder(nn.Module):
         h = Dense(self.n_hidden)(z)
         h += Dense(self.n_hidden)(batch)
 
-        h = nn.LayerNorm(
-            use_scale=False,
-            use_bias=False,
-        )(h)
+        h = nn.BatchNorm(momentum=0.9)(h, use_running_average=not is_training)
         h = nn.relu(h)
         h = nn.Dropout(self.dropout_rate)(h, deterministic=not is_training)
         # skip connection
         h = Dense(self.n_hidden)(jnp.concatenate([h, batch], axis=-1))
-        h = nn.LayerNorm(
-            use_scale=False,
-            use_bias=False,
-        )(h)
+        h = nn.BatchNorm(momentum=0.9)(h, use_running_average=not is_training)
+
         h = nn.relu(h)
         h = nn.Dropout(self.dropout_rate)(h, deterministic=not is_training)
         h = Dense(self.n_input)(h)

--- a/scvi/module/_jaxvae.py
+++ b/scvi/module/_jaxvae.py
@@ -34,11 +34,15 @@ class FlaxEncoder(nn.Module):
         inputs_ = jnp.log1p(inputs)
 
         h = Dense(self.n_hidden)(inputs_)
-        h = nn.BatchNorm(momentum=0.9)(h, use_running_average=not is_training)
+        h = nn.BatchNorm(momentum=0.99, epsilon=0.001)(
+            h, use_running_average=not is_training
+        )
         h = nn.relu(h)
         h = nn.Dropout(self.dropout_rate)(h, deterministic=not is_training)
         h = Dense(self.n_hidden)(h)
-        h = nn.BatchNorm(momentum=0.9)(h, use_running_average=not is_training)
+        h = nn.BatchNorm(momentum=0.99, epsilon=0.001)(
+            h, use_running_average=not is_training
+        )
         h = nn.relu(h)
         h = nn.Dropout(self.dropout_rate)(h, deterministic=not is_training)
 
@@ -63,12 +67,16 @@ class FlaxDecoder(nn.Module):
         h = Dense(self.n_hidden)(z)
         h += Dense(self.n_hidden)(batch)
 
-        h = nn.BatchNorm(momentum=0.9)(h, use_running_average=not is_training)
+        h = nn.BatchNorm(momentum=0.99, epsilon=0.001)(
+            h, use_running_average=not is_training
+        )
         h = nn.relu(h)
         h = nn.Dropout(self.dropout_rate)(h, deterministic=not is_training)
         # skip connection
         h = Dense(self.n_hidden)(jnp.concatenate([h, batch], axis=-1))
-        h = nn.BatchNorm(momentum=0.9)(h, use_running_average=not is_training)
+        h = nn.BatchNorm(momentum=0.99, epsilon=0.001)(
+            h, use_running_average=not is_training
+        )
 
         h = nn.relu(h)
         h = nn.Dropout(self.dropout_rate)(h, deterministic=not is_training)

--- a/scvi/module/_jaxvae.py
+++ b/scvi/module/_jaxvae.py
@@ -131,8 +131,9 @@ class JaxVAE(nn.Module):
         mu = total_count * rho
 
         if self.gene_likelihood == "nb":
+            nb_logits = jnp.log(mu + self.eps) - jnp.log(disp_ + self.eps)
             disp_ = jnp.exp(disp)
-            px = dist.NegativeBinomial2(mean=mu, concentration=disp_)
+            px = dist.NegativeBinomialLogits(logits=nb_logits, total_count=disp_)
         else:
             px = dist.Poisson(mu)
 

--- a/scvi/module/_jaxvae.py
+++ b/scvi/module/_jaxvae.py
@@ -87,7 +87,7 @@ class FlaxDecoder(nn.Module):
 class VAEOutput(NamedTuple):
     mean: jnp.ndarray
     stddev: jnp.ndarray
-    nb: dist.NegativeBinomialLogits
+    px: dist.NegativeBinomialLogits
 
 
 class JaxVAE(nn.Module):
@@ -132,8 +132,8 @@ class JaxVAE(nn.Module):
         if self.gene_likelihood == "nb":
             nb_logits = jnp.log(mu + 1e-6) - jnp.log(disp_ + 1e-6)
             disp_ = jnp.exp(disp)
-            nb = dist.NegativeBinomialLogits(logits=nb_logits, total_count=disp_)
+            px = dist.NegativeBinomialLogits(logits=nb_logits, total_count=disp_)
         else:
-            nb = dist.Poisson(mu)
+            px = dist.Poisson(mu)
 
-        return VAEOutput(mean, stddev, nb)
+        return VAEOutput(mean, stddev, px)

--- a/scvi/module/_jaxvae.py
+++ b/scvi/module/_jaxvae.py
@@ -131,9 +131,8 @@ class JaxVAE(nn.Module):
         mu = total_count * rho
 
         if self.gene_likelihood == "nb":
-            nb_logits = jnp.log(mu + self.eps) - jnp.log(disp_ + self.eps)
             disp_ = jnp.exp(disp)
-            px = dist.NegativeBinomialLogits(logits=nb_logits, total_count=disp_)
+            px = dist.NegativeBinomial2(mean=mu, concentration=disp_)
         else:
             px = dist.Poisson(mu)
 

--- a/scvi/module/_jaxvae.py
+++ b/scvi/module/_jaxvae.py
@@ -85,9 +85,10 @@ class FlaxDecoder(nn.Module):
 
 
 class VAEOutput(NamedTuple):
-    mean: jnp.ndarray
-    stddev: jnp.ndarray
+    rec_loss: jnp.ndarray
+    kl: jnp.ndarray
     px: dist.NegativeBinomialLogits
+    qz: dist.Normal
 
 
 class JaxVAE(nn.Module):
@@ -137,4 +138,7 @@ class JaxVAE(nn.Module):
         else:
             px = dist.Poisson(mu)
 
-        return VAEOutput(mean, stddev, px)
+        rec_loss = -px.log_prob(x).sum(-1)
+        kl_div = dist.kl_divergence(qz, dist.Normal(0, 1)).sum(-1)
+
+        return VAEOutput(rec_loss, kl_div, px, qz)

--- a/scvi/module/_jaxvae.py
+++ b/scvi/module/_jaxvae.py
@@ -28,13 +28,13 @@ class FlaxEncoder(nn.Module):
     is_training: Optional[bool] = None
 
     @nn.compact
-    def __call__(self, input: jnp.ndarray, is_training: bool):
+    def __call__(self, x: jnp.ndarray, is_training: bool):
 
         is_training = nn.merge_param("is_training", self.is_training, is_training)
 
-        input_ = jnp.log1p(input)
+        x_ = jnp.log1p(x)
 
-        h = Dense(self.n_hidden)(input_)
+        h = Dense(self.n_hidden)(x_)
         h = nn.BatchNorm(momentum=0.99, epsilon=0.001)(
             h, use_running_average=not is_training
         )

--- a/scvi/module/_jaxvae.py
+++ b/scvi/module/_jaxvae.py
@@ -1,4 +1,3 @@
-import math
 from typing import NamedTuple, Optional
 
 import jax
@@ -14,8 +13,9 @@ class Dense(nn.Dense):
     def __init__(self, *args, **kwargs):
         # https://github.com/google/jax/blob/ab15db7d8658825afa9709df46f0dea76688d309/jax/_src/nn/initializers.py#L169
         # sqrt 5 comes from PyTorch
-        init = variance_scaling(math.sqrt(5.0), "fan_in", "uniform")
-        kwargs.update({"kernel_init": init})
+        kernel_init = variance_scaling(5.0, "fan_in", "uniform")
+        bias_init = variance_scaling(5.0, "fan_in", "uniform", in_axis=-1)
+        kwargs.update({"kernel_init": kernel_init, "bias_init": bias_init})
         super().__init__(*args, **kwargs)
 
 

--- a/scvi/module/_jaxvae.py
+++ b/scvi/module/_jaxvae.py
@@ -1,0 +1,122 @@
+from typing import NamedTuple
+
+import jax
+import jax.numpy as jnp
+import numpyro.distributions as dist
+from flax import linen as nn
+
+from scvi import REGISTRY_KEYS
+
+
+class FlaxEncoder(nn.Module):
+    n_input: int
+    n_latent: int
+    n_hidden: int
+    dropout_rate: int
+
+    @nn.compact
+    def __call__(self, inputs, is_training):
+        inputs_ = jnp.log1p(inputs)
+
+        # k1, k2 = hk.next_rng_keys(2)
+
+        h = nn.Dense(self.n_hidden)(inputs_)
+        h = nn.LayerNorm(
+            use_scale=False,
+            use_bias=False,
+        )(h)
+        h = nn.relu(h)
+        # h = nn.Dropout(dropout_rate)(h)
+        h = nn.Dense(self.n_hidden)(h)
+        h = nn.LayerNorm(
+            use_scale=False,
+            use_bias=False,
+        )(h)
+        h = nn.relu(h)
+        # h = nn.Dropout(dropout_rate)(h)
+
+        mean = nn.Dense(self.n_latent)(h)
+        log_concentration = nn.Dense(self.n_latent)(h)
+
+        return mean, nn.softplus(log_concentration)
+
+
+class FlaxDecoder(nn.Module):
+    n_input: int
+    dropout_rate: float
+    n_hidden: int
+
+    @nn.compact
+    def __call__(self, inputs, is_training):
+        # disp = nn.get_parameter("disp", (self.n_input,1), init=jnp.ones)
+        disp = self.param("disp", lambda rng, shape: jnp.ones(shape), (self.n_input, 1))
+
+        # k1, k2 = nn.next_rng_keys(2)
+
+        # print(inputs.shape, self.n_hidden)
+        h = nn.Dense(self.n_hidden)(inputs)
+        h = nn.LayerNorm(
+            use_scale=False,
+            use_bias=False,
+        )(h)
+        h = nn.relu(h)
+        # h = nn.Dropout(dropout_rate)(h)
+        # skip connection
+        h = nn.Dense(self.n_hidden)(jnp.concatenate([h, inputs], axis=-1))
+        h = nn.LayerNorm(
+            use_scale=False,
+            use_bias=False,
+        )(h)
+        h = nn.relu(h)
+        # h = nn.Dropout(dropout_rate)(h)
+        h = nn.Dense(self.n_input)(h)
+        return h, disp.ravel()
+
+
+class VAEOutput(NamedTuple):
+    mean: jnp.ndarray
+    stddev: jnp.ndarray
+    nb: dist.NegativeBinomialLogits
+
+
+class JaxVAE(nn.Module):
+    n_input: int
+    n_batch: int
+    n_hidden: int = 128
+    n_latent: int = 30
+    dropout_rate: float = 0.0
+    is_training: bool = False
+    n_layers: int = 1
+
+    @nn.compact
+    def __call__(self, array_dict, z_rng) -> VAEOutput:
+
+        x = array_dict[REGISTRY_KEYS.X_KEY]
+        batch = array_dict[REGISTRY_KEYS.BATCH_KEY]
+
+        # one hot adds an extra dimension
+        batch = jax.nn.one_hot(batch, self.n_batch).squeeze(-2)
+        mean, var = FlaxEncoder(
+            n_input=self.n_input,
+            n_latent=self.n_latent,
+            n_hidden=self.n_hidden,
+            dropout_rate=self.dropout_rate,
+        )(x, self.is_training)
+        stddev = jnp.sqrt(var) + 1e-4
+        z = mean + stddev * jax.random.normal(z_rng, mean.shape)
+        dec_input = jnp.concatenate([z, batch], axis=-1)
+        rho_unnorm, disp = FlaxDecoder(
+            n_input=self.n_input,
+            dropout_rate=self.dropout_rate,
+            n_hidden=self.n_hidden,
+        )(dec_input, self.is_training)
+        disp_ = jnp.exp(disp)
+        rho = jax.nn.softmax(rho_unnorm, axis=-1)
+        total_count = x.sum(-1)[:, jnp.newaxis]
+        mu = total_count * rho
+        nb_logits = jnp.log(mu + 1e-6) - jnp.log(disp_ + 1e-6)
+        disp_ = jnp.exp(disp)
+
+        nb = dist.NegativeBinomialLogits(logits=nb_logits, total_count=disp_)
+
+        return VAEOutput(mean, stddev, nb)

--- a/scvi/module/_jaxvae.py
+++ b/scvi/module/_jaxvae.py
@@ -121,7 +121,7 @@ class JaxVAE(nn.Module):
         z = qz.rsample(z_rng)
         rho_unnorm, disp = FlaxDecoder(
             n_input=self.n_input,
-            dropout_rate=self.dropout_rate,
+            dropout_rate=0.0,
             n_hidden=self.n_hidden,
         )(z, batch, self.is_training)
         disp_ = jnp.exp(disp)

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -95,6 +95,7 @@ def test_jax_scvi():
     )
     model = JaxSCVI(adata, n_latent=n_latent)
     model.train(1, check_val_every_n_epoch=1, train_size=0.5)
+    model.get_latent_representation()
 
 
 def test_scvi(save_path):

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -31,6 +31,7 @@ from scvi.model import (
     TOTALVI,
     CondSCVI,
     DestVI,
+    JaxSCVI,
     LinearSCVI,
 )
 from scvi.model.utils import mde
@@ -81,6 +82,19 @@ LEGACY_SETUP_DICT = {
         "n_continuous_covs": 2,
     },
 }
+
+
+def test_jax_scvi():
+    n_latent = 5
+
+    # Test with size factor.
+    adata = synthetic_iid()
+    JaxSCVI.setup_anndata(
+        adata,
+        batch_key="batch",
+    )
+    model = JaxSCVI(adata, n_latent=n_latent)
+    model.train(1, check_val_every_n_epoch=1, train_size=0.5)
 
 
 def test_scvi(save_path):

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -94,7 +94,11 @@ def test_jax_scvi():
         batch_key="batch",
     )
     model = JaxSCVI(adata, n_latent=n_latent)
-    model.train(1, check_val_every_n_epoch=1, train_size=0.5)
+    model.train(1, train_size=0.5)
+    model.get_latent_representation()
+
+    model = JaxSCVI(adata, n_latent=n_latent, gene_likelihood="poisson")
+    model.train(1, train_size=0.5)
     model.get_latent_representation()
 
 


### PR DESCRIPTION
- Implements a MVP Jax-based scVI model.
- We can continue to add functionality to this during 0.15.x patches and so on.
- Supports GPU and CPU, `get_latent_representation`
- No save/load
- Removes Numba, reimplements nonnegative integer check with jax