### PR TITLE
fix scanvi from_scvi_model

### DIFF
--- a/scvi/model/_scanvi.py
+++ b/scvi/model/_scanvi.py
@@ -1,5 +1,6 @@
 import logging
 import warnings
+from copy import deepcopy
 from typing import List, Optional, Sequence, Union
 
 import numpy as np
@@ -215,7 +216,7 @@ class SCANVI(RNASeqMixin, VAEMixin, ArchesMixin, BaseModelClass):
             # validate new anndata against old model
             scvi_model._validate_anndata(adata)
 
-        scvi_setup_args = scvi_model.adata_manager.registry[_SETUP_ARGS_KEY]
+        scvi_setup_args = deepcopy(scvi_model.adata_manager.registry[_SETUP_ARGS_KEY])
         scvi_labels_key = scvi_setup_args["labels_key"]
         if labels_key is None and scvi_labels_key is None:
             raise ValueError(

--- a/scvi/model/_scanvi.py
+++ b/scvi/model/_scanvi.py
@@ -215,9 +215,9 @@ class SCANVI(RNASeqMixin, VAEMixin, ArchesMixin, BaseModelClass):
             scvi_model._validate_anndata(adata)
 
         scvi_setup_args = scvi_model.adata_manager.registry[_SETUP_ARGS_KEY]
+        scvi_setup_args.update(dict(labels_key=labels_key))
         cls.setup_anndata(
             adata,
-            labels_key=labels_key,
             unlabeled_category=unlabeled_category,
             **scvi_setup_args,
         )

--- a/scvi/model/_scanvi.py
+++ b/scvi/model/_scanvi.py
@@ -212,7 +212,7 @@ class SCANVI(RNASeqMixin, VAEMixin, ArchesMixin, BaseModelClass):
             adata = scvi_model.adata
         else:
             # validate new anndata against old model
-            scvi_model.adata_manager.transfer_fields(adata)
+            scvi_model._validate_anndata(adata)
 
         scvi_setup_args = scvi_model.adata_manager.registry[_SETUP_ARGS_KEY]
         cls.setup_anndata(

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -807,7 +807,14 @@ def test_scanvi(save_path):
     )
     m = SCVI(a, use_observed_lib_size=False)
     a2 = scvi.data.synthetic_iid()
-    scanvi_model = scvi.model.SCANVI.from_scvi_model(m, "labels", "label_0", adata=a2)
+    scanvi_model = scvi.model.SCANVI.from_scvi_model(
+        m, "label_0", labels_key="labels", adata=a2
+    )
+    with pytest.raises(ValueError):
+        scanvi_model = scvi.model.SCANVI.from_scvi_model(
+            m, "label_0", labels_key=None, adata=a2
+        )
+
     # make sure the state_dicts are different objects for the two models
     assert scanvi_model.module.state_dict() is not m.module.state_dict()
     scanvi_pxr = scanvi_model.module.state_dict().get("px_r", None)

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -804,11 +804,10 @@ def test_scanvi(save_path):
     SCVI.setup_anndata(
         a,
         batch_key="batch",
-        labels_key="labels",
     )
     m = SCVI(a, use_observed_lib_size=False)
     a2 = scvi.data.synthetic_iid()
-    scanvi_model = scvi.model.SCANVI.from_scvi_model(m, "label_0", adata=a2)
+    scanvi_model = scvi.model.SCANVI.from_scvi_model(m, "labels", "label_0", adata=a2)
     # make sure the state_dicts are different objects for the two models
     assert scanvi_model.module.state_dict() is not m.module.state_dict()
     scanvi_pxr = scanvi_model.module.state_dict().get("px_r", None)

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -825,7 +825,7 @@ def test_scanvi(save_path):
 
     # Test without label groups
     scanvi_model = scvi.model.SCANVI.from_scvi_model(
-        m, "label_0", use_labels_groups=False
+        m, "label_0", labels_key="labels", use_labels_groups=False
     )
     scanvi_model.train(1)
 


### PR DESCRIPTION
user shouldn't have to specify labels key in the scvi model upfront