### PR TITLE
add batch size to lightning log commands

### DIFF
--- a/scvi/train/_trainingplans.py
+++ b/scvi/train/_trainingplans.py
@@ -218,7 +218,13 @@ class TrainingPlan(pl.LightningModule):
         # e.g., train or val mode
         mode = elbo_metric.mode
         # pytorch lightning handles everything with the torchmetric object
-        self.log(f"elbo_{mode}", elbo_metric, on_step=False, on_epoch=True)
+        self.log(
+            f"elbo_{mode}",
+            elbo_metric,
+            on_step=False,
+            on_epoch=True,
+            batch_size=n_obs_minibatch,
+        )
 
         # log elbo components
         self.log(
@@ -227,6 +233,7 @@ class TrainingPlan(pl.LightningModule):
             reduce_fx=torch.sum,
             on_step=False,
             on_epoch=True,
+            batch_size=n_obs_minibatch,
         )
         self.log(
             f"kl_local_{mode}",
@@ -234,6 +241,7 @@ class TrainingPlan(pl.LightningModule):
             reduce_fx=torch.sum,
             on_step=False,
             on_epoch=True,
+            batch_size=n_obs_minibatch,
         )
         # default aggregation is mean
         self.log(
@@ -241,6 +249,7 @@ class TrainingPlan(pl.LightningModule):
             kl_global,
             on_step=False,
             on_epoch=True,
+            batch_size=n_obs_minibatch,
         )
 
         # accumlate extra metrics passed to loss recorder
@@ -255,6 +264,7 @@ class TrainingPlan(pl.LightningModule):
                 met,
                 on_step=False,
                 on_epoch=True,
+                batch_size=n_obs_minibatch,
             )
 
     def training_step(self, batch, batch_idx, optimizer_idx=0):
@@ -584,7 +594,12 @@ class SemiSupervisedTrainingPlan(TrainingPlan):
         input_kwargs.update(self.loss_kwargs)
         _, _, scvi_losses = self.forward(full_dataset, loss_kwargs=input_kwargs)
         loss = scvi_losses.loss
-        self.log("train_loss", loss, on_epoch=True)
+        self.log(
+            "train_loss",
+            loss,
+            on_epoch=True,
+            batch_size=len(scvi_losses.reconstruction_loss),
+        )
         self.compute_and_log_metrics(scvi_losses, self.elbo_train)
         return loss
 
@@ -604,7 +619,12 @@ class SemiSupervisedTrainingPlan(TrainingPlan):
         input_kwargs.update(self.loss_kwargs)
         _, _, scvi_losses = self.forward(full_dataset, loss_kwargs=input_kwargs)
         loss = scvi_losses.loss
-        self.log("validation_loss", loss, on_epoch=True)
+        self.log(
+            "validation_loss",
+            loss,
+            on_epoch=True,
+            batch_size=len(scvi_losses.reconstruction_loss),
+        )
         self.compute_and_log_metrics(scvi_losses, self.elbo_val)
 
 


### PR DESCRIPTION
I was getting the following warning from lightning due to how we load batches into scANVI. This prevents that.

<img width="1991" alt="Screen Shot 2022-02-24 at 8 35 23 PM" src="https://user-images.githubusercontent.com/10859440/155654435-b4dc3b4e-9983-453d-9886-72301362b68a.png">
