### PR TITLE
FIx NumericalObsField register_field fn

### DIFF
--- a/scvi/data/_manager.py
+++ b/scvi/data/_manager.py
@@ -272,11 +272,6 @@ class AnnDataManager:
         """Returns the state registry for the AnnDataField registered with this instance."""
         self._assert_anndata_registered()
 
-        print(
-            self._registry[_constants._FIELD_REGISTRIES_KEY][registry_key][
-                _constants._STATE_REGISTRY_KEY
-            ]
-        )
         return attrdict(
             self._registry[_constants._FIELD_REGISTRIES_KEY][registry_key][
                 _constants._STATE_REGISTRY_KEY

--- a/scvi/data/_manager.py
+++ b/scvi/data/_manager.py
@@ -272,6 +272,11 @@ class AnnDataManager:
         """Returns the state registry for the AnnDataField registered with this instance."""
         self._assert_anndata_registered()
 
+        print(
+            self._registry[_constants._FIELD_REGISTRIES_KEY][registry_key][
+                _constants._STATE_REGISTRY_KEY
+            ]
+        )
         return attrdict(
             self._registry[_constants._FIELD_REGISTRIES_KEY][registry_key][
                 _constants._STATE_REGISTRY_KEY

--- a/scvi/data/fields/_base_field.py
+++ b/scvi/data/fields/_base_field.py
@@ -60,6 +60,7 @@ class BaseAnnDataField(ABC):
             stored directly on the AnnData object.
         """
         self.validate_field(adata)
+        return dict()
 
     @abstractmethod
     def transfer_field(
@@ -86,6 +87,7 @@ class BaseAnnDataField(ABC):
             A dictionary containing any additional state required for scvi-tools models not
             stored directly on the AnnData object.
         """
+        return dict()
 
     @abstractmethod
     def get_summary_stats(self, state_registry: dict) -> dict:

--- a/scvi/data/fields/_obs_field.py
+++ b/scvi/data/fields/_obs_field.py
@@ -77,7 +77,7 @@ class NumericalObsField(BaseObsField):
             raise KeyError(f"{self.attr_key} not found in adata.obs.")
 
     def register_field(self, adata: AnnData) -> dict:
-        super().register_field(adata)
+        return super().register_field(adata)
 
     def transfer_field(
         self,

--- a/scvi/model/_destvi.py
+++ b/scvi/model/_destvi.py
@@ -97,7 +97,6 @@ class DestVI(UnsupervisedTrainingMixin, BaseModelClass):
         st_adata: AnnData,
         sc_model: CondSCVI,
         vamp_prior_p: int = 50,
-        layer: Optional[str] = None,
         **module_kwargs,
     ):
         """
@@ -106,7 +105,7 @@ class DestVI(UnsupervisedTrainingMixin, BaseModelClass):
         Parameters
         ----------
         st_adata
-            registed anndata object
+            registered anndata object
         sc_model
             trained CondSCVI model
         vamp_prior_p
@@ -128,7 +127,6 @@ class DestVI(UnsupervisedTrainingMixin, BaseModelClass):
                 sc_model.adata, p=vamp_prior_p
             )
 
-        cls.setup_anndata(st_adata, layer=layer)
         return cls(
             st_adata,
             mapping,

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -120,7 +120,7 @@ def test_scvi(save_path):
 
     # tests __repr__
     print(model)
-    # test view_registry
+    # test view_anndata_setup
     model.view_anndata_setup()
     model.view_anndata_setup(hide_state_registries=True)
 
@@ -134,7 +134,7 @@ def test_scvi(save_path):
     model.get_normalized_expression(transform_batch="batch_1")
 
     adata2 = synthetic_iid()
-    # test view_registry with different anndata before transfer setup
+    # test view_anndata_setup with different anndata before transfer setup
     with pytest.raises(ValueError):
         model.view_anndata_setup(adata=adata2)
         model.view_anndata_setup(adata=adata2, hide_state_registries=True)
@@ -146,7 +146,7 @@ def test_scvi(save_path):
     assert latent.shape == (3, n_latent)
     denoised = model.get_normalized_expression(adata2)
     assert denoised.shape == adata.shape
-    # test view_registry with different anndata after transfer setup
+    # test view_anndata_setup with different anndata after transfer setup
     model.view_anndata_setup(adata=adata2)
     model.view_anndata_setup(adata=adata2, hide_state_registries=True)
 
@@ -1202,11 +1202,13 @@ def test_destvi(save_path):
     # step 2 learn destVI with multiple amortization scheme
 
     for amor_scheme in ["both", "none", "proportion", "latent"]:
+        DestVI.setup_anndata(dataset, layer=None)
         spatial_model = DestVI.from_rna_model(
             dataset,
             sc_model,
             amortization=amor_scheme,
         )
+        spatial_model.view_anndata_setup()
         spatial_model.train(max_epochs=1)
         assert not np.isnan(spatial_model.history["elbo_train"].values[0][0])
 


### PR DESCRIPTION
models with NumericalObsField were erroring on `view_anndata_setup` due to empty state registry.