### PR TITLE
Move load prefix kwarg to back

### DIFF
--- a/scvi/external/gimvi/_model.py
+++ b/scvi/external/gimvi/_model.py
@@ -442,10 +442,10 @@ class GIMVI(VAEMixin, BaseModelClass):
     def load(
         cls,
         dir_path: str,
-        prefix: Optional[str] = None,
         adata_seq: Optional[AnnData] = None,
         adata_spatial: Optional[AnnData] = None,
         use_gpu: Optional[Union[str, int, bool]] = None,
+        prefix: Optional[str] = None,
     ):
         """
         Instantiate a model from the saved output.
@@ -454,8 +454,6 @@ class GIMVI(VAEMixin, BaseModelClass):
         ----------
         dir_path
             Path to saved outputs.
-        prefix
-            Prefix of saved file names.
         adata_seq
             AnnData organized in the same way as data used to train model.
             It is not necessary to run :meth:`~scvi.external.GIMVI.setup_anndata`,
@@ -467,6 +465,8 @@ class GIMVI(VAEMixin, BaseModelClass):
         use_gpu
             Load model on default GPU if available (if None or True),
             or index of GPU to use (if int), or name of GPU (if str), or use CPU (if False).
+        prefix
+            Prefix of saved file names.
 
         Returns
         -------

--- a/scvi/model/base/_base_model.py
+++ b/scvi/model/base/_base_model.py
@@ -538,9 +538,9 @@ class BaseModelClass(metaclass=BaseModelMetaClass):
     def load(
         cls,
         dir_path: str,
-        prefix: Optional[str] = None,
         adata: Optional[AnnData] = None,
         use_gpu: Optional[Union[str, int, bool]] = None,
+        prefix: Optional[str] = None,
     ):
         """
         Instantiate a model from the saved output.
@@ -549,8 +549,6 @@ class BaseModelClass(metaclass=BaseModelMetaClass):
         ----------
         dir_path
             Path to saved outputs.
-        prefix
-            Prefix of saved file names.
         adata
             AnnData organized in the same way as data used to train model.
             It is not necessary to run setup_anndata,
@@ -559,6 +557,8 @@ class BaseModelClass(metaclass=BaseModelMetaClass):
         use_gpu
             Load model on default GPU if available (if None or True),
             or index of GPU to use (if int), or name of GPU (if str), or use CPU (if False).
+        prefix
+            Prefix of saved file names.
 
         Returns
         -------


### PR DESCRIPTION
Avoids signature break when `adata` is passed in as an arg and not a kwarg.